### PR TITLE
refactor: style formatting & precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,7 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a plugin for [Eventyay](https://github.com/fossasia/eventyay) that enabl
 This repository enforces code style guidelines via CI. You can run checks locally by installing the development dependencies:
 
 ```bash
-pip install pre-commit ruff black
+pip install pre-commit ruff
 pre-commit install
 
 pre-commit run --all-files

--- a/hubspot/admin.py
+++ b/hubspot/admin.py
@@ -4,8 +4,8 @@ from .models import (
     AuditLog,
     HubSpotEventSettings,
     HubSpotFieldMapping,
-    HubSpotObjectMapping,
     HubSpotOAuthToken,
+    HubSpotObjectMapping,
     ObjectTypeMapping,
     SyncLog,
 )

--- a/hubspot/apps.py
+++ b/hubspot/apps.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 
 from . import __version__
 
+
 try:
     from eventyay.base.plugins import PluginConfig
 except ImportError as e:

--- a/hubspot/apps.py
+++ b/hubspot/apps.py
@@ -1,10 +1,10 @@
 from pathlib import Path
-from django.utils.translation import gettext_lazy as _
+
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import gettext_lazy as _
 from dotenv import load_dotenv
 
 from . import __version__
-
 
 try:
     from eventyay.base.plugins import PluginConfig

--- a/hubspot/client.py
+++ b/hubspot/client.py
@@ -5,6 +5,7 @@ import requests
 
 from .services import get_valid_hubspot_token
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -20,9 +21,7 @@ class HubSpotAPIError(Exception):
 class HubSpotTransientError(HubSpotAPIError):
     """5xx, 429, timeouts — safe to retry."""
 
-    def __init__(
-        self, message, status_code=None, response_body=None, retry_after_seconds=None
-    ):
+    def __init__(self, message, status_code=None, response_body=None, retry_after_seconds=None):
         super().__init__(message, status_code, response_body)
         self.retry_after_seconds = retry_after_seconds
 
@@ -157,18 +156,12 @@ def create_record(event, object_type: str, properties: dict) -> str:
         except ValueError:
             response_body = response.text
 
-        error_msg = (
-            response_body.get("message", "")
-            if isinstance(response_body, dict)
-            else str(response_body)
-        )
+        error_msg = response_body.get("message", "") if isinstance(response_body, dict) else str(response_body)
         match = re.search(r"Existing ID:\s*(\d+)", error_msg)
 
         if match:
             existing_id = match.group(1)
-            logger.info(
-                f"HubSpot 409 Conflict for {object_type}. Existing ID: {existing_id}."
-            )
+            logger.info(f"HubSpot 409 Conflict for {object_type}. Existing ID: {existing_id}.")
             raise HubSpotConflictError(
                 message=f"HubSpot API conflict: record already exists with ID {existing_id}.",
                 existing_id=existing_id,

--- a/hubspot/client.py
+++ b/hubspot/client.py
@@ -1,5 +1,6 @@
 import logging
 import re
+
 import requests
 
 from .services import get_valid_hubspot_token

--- a/hubspot/field_discovery.py
+++ b/hubspot/field_discovery.py
@@ -1,6 +1,7 @@
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.models import Question
 
+
 QUESTION_TYPE_MAP = {
     Question.TYPE_NUMBER: "number",
     Question.TYPE_BOOLEAN: "yes/no",
@@ -456,6 +457,4 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
 
         return fields
 
-    raise ValueError(
-        f"Unknown object_type: {object_type!r}. Expected 'order' or 'order_position'."
-    )
+    raise ValueError(f"Unknown object_type: {object_type!r}. Expected 'order' or 'order_position'.")

--- a/hubspot/forms.py
+++ b/hubspot/forms.py
@@ -1,13 +1,13 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from eventyay.base.forms.widgets import DatePickerWidget
 from eventyay.base.models import Event
 from eventyay.control.forms.filter import FilterForm
-from eventyay.base.forms.widgets import DatePickerWidget
 
 from .models import (
     HubSpotEventSettings,
-    ObjectTypeMapping,
     HubSpotFieldMapping,
+    ObjectTypeMapping,
     SyncMode,
 )
 
@@ -264,9 +264,9 @@ class BaseHubSpotFieldMappingFormSet(forms.BaseModelFormSet):
                 (SyncMode.IDENTIFIER, _("Identifier"))
             ]
             form.fields["sync_mode"].widget.attrs["readonly"] = True
-            form.fields["sync_mode"].widget.attrs[
-                "style"
-            ] = "pointer-events: none; background-color: #eee;"
+            form.fields["sync_mode"].widget.attrs["style"] = (
+                "pointer-events: none; background-color: #eee;"
+            )
             if not form.initial.get("sync_mode"):
                 form.initial["sync_mode"] = SyncMode.IDENTIFIER
         else:

--- a/hubspot/forms.py
+++ b/hubspot/forms.py
@@ -57,9 +57,7 @@ class HubSpotLogFilterForm(FilterForm):
     )
     query = forms.CharField(
         label=_("Search for..."),
-        widget=forms.TextInput(
-            attrs={"placeholder": _("Search for..."), "autofocus": "autofocus"}
-        ),
+        widget=forms.TextInput(attrs={"placeholder": _("Search for..."), "autofocus": "autofocus"}),
         required=False,
     )
     date_from = forms.DateField(
@@ -110,10 +108,7 @@ class BaseObjectTypeMappingFormSet(forms.BaseInlineFormSet):
                 continue
             if pair in seen:
                 raise forms.ValidationError(
-                    _(
-                        "Duplicate mapping: each eventyay / HubSpot object-type "
-                        "pair may only appear once per event."
-                    )
+                    _("Duplicate mapping: each eventyay / HubSpot object-type pair may only appear once per event.")
                 )
             seen.add(pair)
         super().clean()
@@ -143,23 +138,13 @@ class HubSpotFieldMappingForm(forms.ModelForm):
 
             if ey_type and hs_type:
                 if ey_type == "yes/no" and hs_type != "yes/no":
-                    warnings.append(
-                        _(
-                            "Warning: Possible type mismatch. Mapping a yes/no field to a different type."
-                        )
-                    )
+                    warnings.append(_("Warning: Possible type mismatch. Mapping a yes/no field to a different type."))
                 elif ey_type != "yes/no" and hs_type == "yes/no":
                     warnings.append(
-                        _(
-                            "Warning: Possible type mismatch. Mapping a non-boolean field to a yes/no field."
-                        )
+                        _("Warning: Possible type mismatch. Mapping a non-boolean field to a yes/no field.")
                     )
                 elif ey_type == "number" and hs_type not in ("number", "text"):
-                    warnings.append(
-                        _(
-                            "Warning: Possible type mismatch. Mapping a number field to a different type."
-                        )
-                    )
+                    warnings.append(_("Warning: Possible type mismatch. Mapping a number field to a different type."))
         return warnings
 
     def _build_choices(self, fields_list):
@@ -199,9 +184,7 @@ class HubSpotFieldMappingForm(forms.ModelForm):
         self.warnings = []
 
         self.ey_types = {f["key"]: f.get("data_type", "text") for f in eventyay_fields}
-        self.hs_types = {
-            f["key"]: f.get("data_type", "text") for f in hubspot_properties
-        }
+        self.hs_types = {f["key"]: f.get("data_type", "text") for f in hubspot_properties}
 
         ey_choices = self._build_choices(eventyay_fields)
 
@@ -248,11 +231,7 @@ class BaseHubSpotFieldMappingFormSet(forms.BaseModelFormSet):
         super().add_fields(form, index)
 
         is_identifier = False
-        if (
-            form.instance
-            and form.instance.pk
-            and form.instance.sync_mode == SyncMode.IDENTIFIER
-        ):
+        if form.instance and form.instance.pk and form.instance.sync_mode == SyncMode.IDENTIFIER:
             is_identifier = True
         elif index == 0 and not self.initial_form_count():
             # Auto-mark slot 0 as the identifier only when there are no saved
@@ -260,21 +239,13 @@ class BaseHubSpotFieldMappingFormSet(forms.BaseModelFormSet):
             is_identifier = True
 
         if is_identifier:
-            form.fields["sync_mode"].widget.choices = [
-                (SyncMode.IDENTIFIER, _("Identifier"))
-            ]
+            form.fields["sync_mode"].widget.choices = [(SyncMode.IDENTIFIER, _("Identifier"))]
             form.fields["sync_mode"].widget.attrs["readonly"] = True
-            form.fields["sync_mode"].widget.attrs["style"] = (
-                "pointer-events: none; background-color: #eee;"
-            )
+            form.fields["sync_mode"].widget.attrs["style"] = "pointer-events: none; background-color: #eee;"
             if not form.initial.get("sync_mode"):
                 form.initial["sync_mode"] = SyncMode.IDENTIFIER
         else:
-            choices = [
-                c
-                for c in form.fields["sync_mode"].choices
-                if c[0] != SyncMode.IDENTIFIER
-            ]
+            choices = [c for c in form.fields["sync_mode"].choices if c[0] != SyncMode.IDENTIFIER]
             form.fields["sync_mode"].widget.choices = choices
             if form.initial.get("sync_mode") == SyncMode.IDENTIFIER:
                 form.initial["sync_mode"] = SyncMode.OVERWRITE
@@ -300,9 +271,7 @@ class BaseHubSpotFieldMappingFormSet(forms.BaseModelFormSet):
             if eventyay_field:
                 if eventyay_field in seen_fields:
                     raise forms.ValidationError(
-                        _(
-                            "You cannot map the same eventyay field ('%(field)s') multiple times."
-                        ),
+                        _("You cannot map the same eventyay field ('%(field)s') multiple times."),
                         params={"field": eventyay_field},
                         code="duplicate_field",
                     )
@@ -315,9 +284,7 @@ class BaseHubSpotFieldMappingFormSet(forms.BaseModelFormSet):
             )
         elif identifier_count > 1:
             raise forms.ValidationError(
-                _(
-                    "Only one row can be set as 'Identifier'. You have selected %(count)d."
-                ),
+                _("Only one row can be set as 'Identifier'. You have selected %(count)d."),
                 params={"count": identifier_count},
                 code="multiple_identifiers",
             )

--- a/hubspot/models.py
+++ b/hubspot/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.db.models import JSONField
 from django.utils.translation import gettext_lazy as _
 from django_scopes import ScopedManager
+
 from .utils import decrypt, encrypt
 
 

--- a/hubspot/models.py
+++ b/hubspot/models.py
@@ -46,9 +46,7 @@ class HubSpotOAuthToken(models.Model):
     objects = ScopedManager(organizer="event__organizer")
     _access_token = models.TextField(db_column="access_token")
     _refresh_token = models.TextField(db_column="refresh_token")
-    token_type = models.CharField(
-        max_length=50, choices=TokenType.choices, default=TokenType.BEARER
-    )
+    token_type = models.CharField(max_length=50, choices=TokenType.choices, default=TokenType.BEARER)
     expires_at = models.DateTimeField(null=True, blank=True)
     hub_id = models.CharField(max_length=100, blank=True)
     hub_name = models.CharField(max_length=200, blank=True)
@@ -100,9 +98,7 @@ class OrganizerHubSpotOAuthToken(models.Model):
     objects = ScopedManager(organizer="organizer")
     _access_token = models.TextField(db_column="access_token")
     _refresh_token = models.TextField(db_column="refresh_token")
-    token_type = models.CharField(
-        max_length=50, choices=TokenType.choices, default=TokenType.BEARER
-    )
+    token_type = models.CharField(max_length=50, choices=TokenType.choices, default=TokenType.BEARER)
     expires_at = models.DateTimeField(null=True, blank=True)
     hub_id = models.CharField(max_length=100, blank=True)
     hub_name = models.CharField(max_length=200, blank=True)
@@ -138,9 +134,7 @@ class HubSpotEventSettings(models.Model):
     event = models.OneToOneField("base.Event", on_delete=models.CASCADE)
     objects = ScopedManager(organizer="event__organizer")
     sync_enabled = models.BooleanField(default=False)
-    auto_sync_enabled = models.BooleanField(
-        default=True, verbose_name=_("Sync automatically")
-    )
+    auto_sync_enabled = models.BooleanField(default=True, verbose_name=_("Sync automatically"))
     sync_contacts = models.BooleanField(default=True)
     sync_deals = models.BooleanField(default=True)
     deal_pipeline = models.CharField(max_length=200, blank=True)
@@ -188,9 +182,7 @@ class HubSpotFieldMapping(models.Model):
     eventyay_field = models.CharField(max_length=190)
     hubspot_object_type = models.CharField(max_length=50)
     hubspot_property = models.CharField(max_length=190)
-    sync_mode = models.CharField(
-        max_length=20, choices=SyncMode.choices, default=SyncMode.OVERWRITE
-    )
+    sync_mode = models.CharField(max_length=20, choices=SyncMode.choices, default=SyncMode.OVERWRITE)
     is_active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -212,9 +204,7 @@ class HubSpotFieldMapping(models.Model):
 class SyncLog(models.Model):
     event = models.ForeignKey("base.Event", on_delete=models.CASCADE)
     objects = ScopedManager(organizer="event__organizer")
-    object_mapping = models.ForeignKey(
-        HubSpotObjectMapping, null=True, blank=True, on_delete=models.SET_NULL
-    )
+    object_mapping = models.ForeignKey(HubSpotObjectMapping, null=True, blank=True, on_delete=models.SET_NULL)
     action = models.CharField(max_length=20, choices=SyncAction.choices)
     direction = models.CharField(max_length=10, choices=SyncDirection.choices)
     status = models.CharField(max_length=10, choices=SyncStatus.choices)
@@ -247,9 +237,7 @@ class AuditAction(models.TextChoices):
 
 class AuditLog(models.Model):
     organizer = models.ForeignKey("base.Organizer", on_delete=models.CASCADE)
-    event = models.ForeignKey(
-        "base.Event", null=True, blank=True, on_delete=models.SET_NULL
-    )
+    event = models.ForeignKey("base.Event", null=True, blank=True, on_delete=models.SET_NULL)
     action = models.CharField(max_length=20, choices=AuditAction.choices)
     ip_address = models.GenericIPAddressField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
@@ -277,12 +265,8 @@ class HubSpotObjectType(models.TextChoices):
 class ObjectTypeMapping(models.Model):
     event = models.ForeignKey("base.Event", on_delete=models.CASCADE)
     objects = ScopedManager(organizer="event__organizer")
-    eventyay_object_type = models.CharField(
-        max_length=50, choices=EventyayObjectType.choices
-    )
-    hubspot_object_type = models.CharField(
-        max_length=50, choices=HubSpotObjectType.choices
-    )
+    eventyay_object_type = models.CharField(max_length=50, choices=EventyayObjectType.choices)
+    hubspot_object_type = models.CharField(max_length=50, choices=HubSpotObjectType.choices)
     position = models.PositiveIntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -294,7 +278,4 @@ class ObjectTypeMapping(models.Model):
         ordering = ["position", "pk"]
 
     def __str__(self):
-        return (
-            f"{self.get_eventyay_object_type_display()}"
-            f" \u2192 {self.get_hubspot_object_type_display()}"
-        )
+        return f"{self.get_eventyay_object_type_display()} \u2192 {self.get_hubspot_object_type_display()}"

--- a/hubspot/services.py
+++ b/hubspot/services.py
@@ -1,7 +1,9 @@
 import datetime
-import os
 import logging
+import os
+
 import requests
+from django.core.cache import cache
 from django.db import transaction
 from django.utils.timezone import now
 from django_scopes import scope
@@ -18,7 +20,6 @@ from .models import (
     SyncLog,
     SyncStatus,
 )
-from django.core.cache import cache
 
 
 class HubSpotFetchError(Exception):

--- a/hubspot/services.py
+++ b/hubspot/services.py
@@ -28,9 +28,7 @@ class HubSpotFetchError(Exception):
     pass
 
 
-def get_hubspot_properties(
-    event, object_type: str, force_sync: bool = False
-) -> list[dict]:
+def get_hubspot_properties(event, object_type: str, force_sync: bool = False) -> list[dict]:
     """
     Returns synced HubSpot properties from the cache.
     If no complete sync exists, fetches synchronously.
@@ -56,9 +54,7 @@ def get_hubspot_properties(
     is_stale = False
     if cached_data:
         fetched_at = cached_data.get("fetched_at")
-        if not fetched_at or fetched_at < now() - datetime.timedelta(
-            minutes=ttl_minutes
-        ):
+        if not fetched_at or fetched_at < now() - datetime.timedelta(minutes=ttl_minutes):
             is_stale = True
 
     if not cached_data:
@@ -90,9 +86,7 @@ def get_hubspot_properties(
             if force_sync or cache.add(rate_limit_key, "1", timeout=30):
                 from .tasks import refresh_hubspot_properties_task
 
-                refresh_hubspot_properties_task.apply_async(
-                    args=[event.id, object_type]
-                )
+                refresh_hubspot_properties_task.apply_async(args=[event.id, object_type])
             else:
                 cache.delete(lock_key)
 
@@ -120,9 +114,7 @@ def sync_hubspot_properties(event, object_type: str) -> list[dict]:
             params["after"] = cursor
 
         try:
-            response = requests.get(
-                base_url, headers=headers, params=params, timeout=15
-            )
+            response = requests.get(base_url, headers=headers, params=params, timeout=15)
             if response.status_code == 429:
                 retry_after = response.headers.get("Retry-After")
                 e = HubSpotFetchError("Rate limited by HubSpot")
@@ -277,10 +269,7 @@ def get_valid_hubspot_token(event) -> str | None:
         # 1. Try event token
         try:
             event_token = HubSpotOAuthToken.objects.select_for_update().get(event=event)
-            if (
-                event_token.expires_at
-                and event_token.expires_at > now() + datetime.timedelta(minutes=5)
-            ):
+            if event_token.expires_at and event_token.expires_at > now() + datetime.timedelta(minutes=5):
                 return event_token.access_token
             return _refresh_token_record(event_token, event, is_organizer=False)
         except HubSpotOAuthToken.DoesNotExist:
@@ -288,9 +277,7 @@ def get_valid_hubspot_token(event) -> str | None:
 
         # 2. Check Organizer settings
         try:
-            org_settings = OrganizerHubSpotSettings.objects.get(
-                organizer=event.organizer
-            )
+            org_settings = OrganizerHubSpotSettings.objects.get(organizer=event.organizer)
             if not org_settings.sync_enabled:
                 return None
         except OrganizerHubSpotSettings.DoesNotExist:
@@ -298,13 +285,8 @@ def get_valid_hubspot_token(event) -> str | None:
 
         # 3. Try Organizer token
         try:
-            org_token = OrganizerHubSpotOAuthToken.objects.select_for_update().get(
-                organizer=event.organizer
-            )
-            if (
-                org_token.expires_at
-                and org_token.expires_at > now() + datetime.timedelta(minutes=5)
-            ):
+            org_token = OrganizerHubSpotOAuthToken.objects.select_for_update().get(organizer=event.organizer)
+            if org_token.expires_at and org_token.expires_at > now() + datetime.timedelta(minutes=5):
                 return org_token.access_token
             return _refresh_token_record(org_token, event.organizer, is_organizer=True)
         except OrganizerHubSpotOAuthToken.DoesNotExist:
@@ -327,13 +309,9 @@ def is_sync_enabled(event) -> bool:
         if HubSpotOAuthToken.objects.filter(event=event).exists():
             return True
 
-        org_settings = OrganizerHubSpotSettings.objects.filter(
-            organizer=event.organizer
-        ).first()
+        org_settings = OrganizerHubSpotSettings.objects.filter(organizer=event.organizer).first()
         if org_settings is not None and org_settings.sync_enabled:
-            if OrganizerHubSpotOAuthToken.objects.filter(
-                organizer=event.organizer
-            ).exists():
+            if OrganizerHubSpotOAuthToken.objects.filter(organizer=event.organizer).exists():
                 return True
 
         return False

--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -115,9 +115,7 @@ def _enqueue_hubspot_sync(sender, order, **kwargs):
         # Deduplicate multiple signals for the same order within a short window
         cache_key = f"hubspot_sync_enqueued_{order.id}"
         if cache.add(cache_key, "1", timeout=5):
-            sync_order_to_hubspot.apply_async(
-                args=[order.id, order.event.id], countdown=5
-            )
+            sync_order_to_hubspot.apply_async(args=[order.id, order.event.id], countdown=5)
 
     transaction.on_commit(enqueue_task)
 
@@ -180,9 +178,7 @@ def clear_audit_logs(sender, **kwargs):
 
 @receiver(order_info, dispatch_uid="hubspot_control_order_info")
 def control_order_info(sender, request, order, **kwargs):
-    if not request.user.has_event_permission(
-        request.organizer, request.event, "can_view_orders", request
-    ):
+    if not request.user.has_event_permission(request.organizer, request.event, "can_view_orders", request):
         return ""
 
     is_connected = False
@@ -217,11 +213,7 @@ def control_order_info(sender, request, order, **kwargs):
 
     if mappings:
         mapping_ids = [m.id for m in mappings]
-        latest_log = (
-            SyncLog.objects.filter(object_mapping_id__in=mapping_ids)
-            .order_by("-created_at")
-            .first()
-        )
+        latest_log = SyncLog.objects.filter(object_mapping_id__in=mapping_ids).order_by("-created_at").first()
         last_synced_at = max(
             (m.last_synced_at for m in mappings if m.last_synced_at is not None),
             default=None,
@@ -273,9 +265,7 @@ def control_order_info(sender, request, order, **kwargs):
             if not has_mapping_changes:
                 sync_needed = False
 
-    can_sync = request.user.has_event_permission(
-        request.organizer, request.event, "can_change_event_settings", request
-    )
+    can_sync = request.user.has_event_permission(request.organizer, request.event, "can_change_event_settings", request)
 
     template = get_template("hubspot/control_order_info.html")
     ctx = {

--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -1,32 +1,37 @@
+from datetime import timedelta
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from django.db import transaction
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.template.loader import get_template
 from django.urls import resolve, reverse
+from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
-from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
-from eventyay.base.models import Order, OrderPosition
-from eventyay.base.signals import periodic_task
-from django.db import transaction
-from eventyay.control.signals import nav_event, nav_organizer
-from eventyay.control.signals import order_info
 from django_scopes import scope
-from eventyay.base.signals import order_placed, order_paid, order_canceled
-from .tasks import sync_order_to_hubspot
+from eventyay.base.models import Order, OrderPosition
+from eventyay.base.signals import (
+    order_canceled,
+    order_paid,
+    order_placed,
+    periodic_task,
+)
+from eventyay.control.signals import nav_event, nav_organizer, order_info
+
 from .models import (
-    HubSpotEventSettings,
-    ObjectTypeMapping,
-    HubSpotFieldMapping,
-    HubSpotObjectMapping,
-    HubSpotOAuthToken,
     AuditLog,
-    SyncLog,
+    HubSpotEventSettings,
+    HubSpotFieldMapping,
+    HubSpotOAuthToken,
+    HubSpotObjectMapping,
+    ObjectTypeMapping,
     SyncAction,
     SyncDirection,
+    SyncLog,
     SyncStatus,
 )
-from django.utils.timezone import now
-from datetime import timedelta
+from .tasks import sync_order_to_hubspot
 
 
 @receiver(nav_event, dispatch_uid="hubspot_nav")
@@ -77,8 +82,8 @@ def _enqueue_hubspot_sync(sender, order, **kwargs):
     with scope(organizer=order.event.organizer):
         from .services import (
             get_valid_hubspot_token,
-            is_sync_enabled,
             is_auto_sync_enabled,
+            is_sync_enabled,
         )
 
         if not is_sync_enabled(order.event):

--- a/hubspot/sync_logic.py
+++ b/hubspot/sync_logic.py
@@ -21,9 +21,7 @@ def get_active_mappings_with_fields(event):
     position_ct = ContentType.objects.get_for_model(OrderPosition)
 
     for mapping in active_mappings:
-        content_type = (
-            order_ct if mapping.eventyay_object_type == "order" else position_ct
-        )
+        content_type = order_ct if mapping.eventyay_object_type == "order" else position_ct
         has_valid_fields = (
             HubSpotFieldMapping.objects.filter(
                 event=event,
@@ -55,15 +53,11 @@ def get_unsynced_querysets(event):
         )
 
         if mapping.eventyay_object_type == "order":
-            qs = Order.objects.filter(event=event, status=Order.STATUS_PAID).exclude(
-                id__in=synced_ids
-            )
+            qs = Order.objects.filter(event=event, status=Order.STATUS_PAID).exclude(id__in=synced_ids)
             results.append((mapping, content_type, qs))
         elif mapping.eventyay_object_type == "order_position":
             qs = (
-                OrderPosition.objects.filter(
-                    order__event=event, order__status=Order.STATUS_PAID
-                )
+                OrderPosition.objects.filter(order__event=event, order__status=Order.STATUS_PAID)
                 .select_related("order")
                 .exclude(id__in=synced_ids)
             )

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from celery import shared_task
 from django.conf import settings
@@ -37,6 +37,7 @@ from .services import (
     sync_hubspot_properties,
 )
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,11 +60,7 @@ def _resolve_eventyay_field(obj: Any, key: str) -> Any:
     """Helper to extract a specific field from Order or OrderPosition based on field_discovery keys"""
     # Event fields
     if key.startswith("event_"):
-        event = (
-            obj.event
-            if hasattr(obj, "event")
-            else (obj.order.event if hasattr(obj, "order") else None)
-        )
+        event = obj.event if hasattr(obj, "event") else (obj.order.event if hasattr(obj, "order") else None)
         if not event:
             return None
         if key == "event_slug":
@@ -209,9 +206,7 @@ def _resolve_eventyay_field(obj: Any, key: str) -> Any:
     return getattr(obj, key, None)
 
 
-def resolve_hubspot_properties(
-    obj: Any, object_mapping: ObjectTypeMapping
-) -> Dict[str, Any]:
+def resolve_hubspot_properties(obj: Any, object_mapping: ObjectTypeMapping) -> dict[str, Any]:
     """
     Takes an eventyay object (Order or OrderPosition) and an ObjectTypeMapping,
     and returns a dict of HubSpot property values using the field mappings.
@@ -226,9 +221,7 @@ def resolve_hubspot_properties(
 
     properties = {}
     try:
-        hubspot_props = get_hubspot_properties(
-            object_mapping.event, object_mapping.hubspot_object_type
-        )
+        hubspot_props = get_hubspot_properties(object_mapping.event, object_mapping.hubspot_object_type)
         hubspot_props_dict = {p["key"]: p for p in hubspot_props}
     except HubSpotFetchError as e:
         logger.error(f"Could not load HubSpot properties: {e}")
@@ -236,11 +229,10 @@ def resolve_hubspot_properties(
 
     if not hubspot_props_dict and field_mappings.exists():
         logger.warning(
-            f"No HubSpot properties found for {object_mapping.hubspot_object_type} on event {object_mapping.event.id}, but field mappings exist."
+            f"No HubSpot properties found for {object_mapping.hubspot_object_type} on event {object_mapping.event.id}, "
+            "but field mappings exist."
         )
-        raise HubSpotTransientError(
-            f"HubSpot properties not available for {object_mapping.hubspot_object_type}."
-        )
+        raise HubSpotTransientError(f"HubSpot properties not available for {object_mapping.hubspot_object_type}.")
 
     for mapping in field_mappings:
         val = None
@@ -331,16 +323,12 @@ def sync_order_to_hubspot(self, order_id: int, event_id: int):
             return
 
         if order.status != Order.STATUS_PAID:
-            logger.info(
-                f"Order {order_id} is not paid (status: {order.status}). Skipping sync."
-            )
+            logger.info(f"Order {order_id} is not paid (status: {order.status}). Skipping sync.")
             return
 
         active_mappings = ObjectTypeMapping.objects.filter(event=event)
         if not active_mappings.exists():
-            logger.info(
-                f"No active object mappings found for event {event_id}. Skipping sync for order {order_id}."
-            )
+            logger.info(f"No active object mappings found for event {event_id}. Skipping sync for order {order_id}.")
             # Clean up pending logs for this order
             SyncLog.objects.filter(
                 event=event,
@@ -407,22 +395,16 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
     existing_properties = {}
     if existing_id:
         fill_if_empty_fields = [
-            prop
-            for prop, val in raw_properties.items()
-            if mapping_modes.get(prop) == SyncMode.FILL_IF_EMPTY
+            prop for prop, val in raw_properties.items() if mapping_modes.get(prop) == SyncMode.FILL_IF_EMPTY
         ]
         if fill_if_empty_fields:
             try:
-                existing_properties = get_record(
-                    event, config.hubspot_object_type, existing_id, fill_if_empty_fields
-                )
+                existing_properties = get_record(event, config.hubspot_object_type, existing_id, fill_if_empty_fields)
             except HubSpotTransientError as e:
                 raise e
             except HubSpotPermanentError as e:
                 # If we fail to fetch, it's safer to not overwrite anything
-                logger.warning(
-                    f"Could not fetch record {existing_id} from HubSpot: {e}"
-                )
+                logger.warning(f"Could not fetch record {existing_id} from HubSpot: {e}")
 
     properties_to_send = {}
     for prop, val in raw_properties.items():
@@ -463,9 +445,7 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
                 action=SyncAction.UPDATE if existing_id else SyncAction.CREATE,
                 direction=SyncDirection.PUSH,
                 status=SyncStatus.SUCCESS,
-                detail={
-                    "message": "No properties to sync based on mappings and current values"
-                },
+                detail={"message": "No properties to sync based on mappings and current values"},
             )
         return
 
@@ -473,15 +453,11 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
         conflict_detected = False
         if existing_id:
             try:
-                hubspot_id = update_record(
-                    event, config.hubspot_object_type, existing_id, properties_to_send
-                )
+                hubspot_id = update_record(event, config.hubspot_object_type, existing_id, properties_to_send)
                 action = SyncAction.UPDATE
             except HubSpotRecordNotFoundError:
                 try:
-                    hubspot_id = create_record(
-                        event, config.hubspot_object_type, properties_to_send
-                    )
+                    hubspot_id = create_record(event, config.hubspot_object_type, properties_to_send)
                     action = SyncAction.CREATE
                 except HubSpotConflictError as conflict:
                     existing_id = conflict.existing_id
@@ -489,9 +465,7 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
                     conflict_detected = True
         else:
             try:
-                hubspot_id = create_record(
-                    event, config.hubspot_object_type, properties_to_send
-                )
+                hubspot_id = create_record(event, config.hubspot_object_type, properties_to_send)
                 action = SyncAction.CREATE
             except HubSpotConflictError as conflict:
                 existing_id = conflict.existing_id
@@ -499,12 +473,11 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
                 conflict_detected = True
 
         if action == SyncAction.UPDATE and conflict_detected:
-            # We must re-evaluate properties using the newly discovered existing_id to respect FILL_IF_NEW / FILL_IF_EMPTY!
+            # We must re-evaluate properties using the newly discovered existing_id
+            # to respect FILL_IF_NEW / FILL_IF_EMPTY!
             existing_properties = {}
             fill_if_empty_fields = [
-                prop
-                for prop, val in raw_properties.items()
-                if mapping_modes.get(prop) == SyncMode.FILL_IF_EMPTY
+                prop for prop, val in raw_properties.items() if mapping_modes.get(prop) == SyncMode.FILL_IF_EMPTY
             ]
             if fill_if_empty_fields:
                 try:
@@ -517,9 +490,7 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
                 except HubSpotTransientError as e:
                     raise e
                 except HubSpotPermanentError as e:
-                    logger.warning(
-                        f"Could not fetch record {existing_id} from HubSpot on conflict: {e}"
-                    )
+                    logger.warning(f"Could not fetch record {existing_id} from HubSpot on conflict: {e}")
 
             properties_to_send = {}
             for prop, val in raw_properties.items():
@@ -537,9 +508,7 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
                         properties_to_send[prop] = val
 
             if properties_to_send:
-                hubspot_id = update_record(
-                    event, config.hubspot_object_type, existing_id, properties_to_send
-                )
+                hubspot_id = update_record(event, config.hubspot_object_type, existing_id, properties_to_send)
             else:
                 hubspot_id = existing_id or ""
 
@@ -592,19 +561,13 @@ def sync_all_mappings_task(self, event_id: int):
     which processes all active object/field mappings for each order.
     """
     with scopes_disabled():
-        order_ids = list(
-            Order.objects.filter(
-                event_id=event_id, status=Order.STATUS_PAID
-            ).values_list("id", flat=True)
-        )
+        order_ids = list(Order.objects.filter(event_id=event_id, status=Order.STATUS_PAID).values_list("id", flat=True))
 
     if not order_ids:
         logger.info(f"No orders found for event {event_id}. Nothing to sync.")
         return
 
-    logger.info(
-        f"Found {len(order_ids)} orders for event {event_id}. Queuing sync tasks."
-    )
+    logger.info(f"Found {len(order_ids)} orders for event {event_id}. Queuing sync tasks.")
     for order_id in order_ids:
         sync_order_to_hubspot.apply_async(args=[order_id, event_id], countdown=0)
 
@@ -630,9 +593,7 @@ def refresh_hubspot_properties_task(self, event_id: int, object_type: str):
     try:
         with scope(organizer=event.organizer):
             properties = sync_hubspot_properties(event, object_type)
-        cache.set(
-            data_key, {"fetched_at": now(), "properties": properties}, timeout=None
-        )
+        cache.set(data_key, {"fetched_at": now(), "properties": properties}, timeout=None)
         cache.delete(error_key)
         cache.delete(lock_key)
         cache.delete(manual_sync_lock_key)

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -2,30 +2,23 @@ import logging
 from typing import Any, Dict
 
 from celery import shared_task
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
 from django.db import transaction
+from django.urls import reverse
 from django.utils.timezone import now
 from django_scopes import scope, scopes_disabled
-from django.conf import settings
-from django.urls import reverse
-from django.core.cache import cache
-
 from eventyay.base.models import Event, Order, OrderPosition
 
 from .client import (
-    HubSpotTransientError,
+    HubSpotConflictError,
     HubSpotPermanentError,
     HubSpotRecordNotFoundError,
-    HubSpotConflictError,
+    HubSpotTransientError,
     create_record,
-    update_record,
     get_record,
-)
-from .services import (
-    get_valid_hubspot_token,
-    get_hubspot_properties,
-    sync_hubspot_properties,
-    HubSpotFetchError,
+    update_record,
 )
 from .models import (
     HubSpotFieldMapping,
@@ -37,7 +30,12 @@ from .models import (
     SyncMode,
     SyncStatus,
 )
-
+from .services import (
+    HubSpotFetchError,
+    get_hubspot_properties,
+    get_valid_hubspot_token,
+    sync_hubspot_properties,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/hubspot/urls.py
+++ b/hubspot/urls.py
@@ -19,6 +19,7 @@ from hubspot.views import (
     SyncRetryBulkView,
 )
 
+
 urlpatterns = [
     path(
         "control/event/<orgslug:organizer>/<slug:event>/hubspot/",

--- a/hubspot/urls.py
+++ b/hubspot/urls.py
@@ -1,21 +1,22 @@
 from django.urls import path
+
 from hubspot.views import (
+    DismissSyncView,
     EventHubSpotCallbackView,
     EventHubSpotConnectView,
     EventHubSpotDisconnectView,
     EventHubSpotFieldMappingView,
-    EventHubSpotSettingsView,
     EventHubSpotLogView,
+    EventHubSpotSettingsView,
     EventHubSpotSyncMappingView,
-    OrganizerHubSpotSettingsView,
     OrganizerHubSpotConnectView,
     OrganizerHubSpotDisconnectView,
-    SyncProblemsView,
-    RetrySyncView,
+    OrganizerHubSpotSettingsView,
     RetryAllFailedView,
-    SyncRetryBulkView,
-    DismissSyncView,
+    RetrySyncView,
     SyncOrderNowView,
+    SyncProblemsView,
+    SyncRetryBulkView,
 )
 
 urlpatterns = [

--- a/hubspot/utils.py
+++ b/hubspot/utils.py
@@ -11,9 +11,7 @@ from django.utils.translation import gettext_lazy as _
 
 @lru_cache(maxsize=1)
 def _get_fernet() -> Fernet:
-    key = base64.urlsafe_b64encode(
-        hashlib.sha256(settings.SECRET_KEY.encode()).digest()
-    )
+    key = base64.urlsafe_b64encode(hashlib.sha256(settings.SECRET_KEY.encode()).digest())
     return Fernet(key)
 
 
@@ -139,31 +137,21 @@ class ActivityLogSequence:
                 content_type_name = log.object_mapping.content_type.name.title()
                 model_name = log.object_mapping.content_type.model
                 if model_name == "orderposition" and hasattr(obj, "order"):
-                    attendee_info = getattr(
-                        obj, "attendee_name_cached", None
-                    ) or getattr(obj, "attendee_email", None)
+                    attendee_info = getattr(obj, "attendee_name_cached", None) or getattr(obj, "attendee_email", None)
                     if not attendee_info and hasattr(obj.order, "email"):
                         attendee_info = obj.order.email
-                    order_info = (
-                        f" for Order {obj.order.code}"
-                        if hasattr(obj.order, "code")
-                        else ""
-                    )
+                    order_info = f" for Order {obj.order.code}" if hasattr(obj.order, "code") else ""
                     info_str = f" ({attendee_info})" if attendee_info else ""
                     obj_name = f"{content_type_name} {obj}{order_info}{info_str}"
                 elif model_name == "order" and hasattr(obj, "code"):
-                    email_str = (
-                        f" ({obj.email})" if hasattr(obj, "email") and obj.email else ""
-                    )
+                    email_str = f" ({obj.email})" if hasattr(obj, "email") and obj.email else ""
                     obj_name = f"{content_type_name} {obj.code}{email_str}"
                 else:
                     obj_name = f"{content_type_name} {obj}"
             elif log.object_mapping.content_type:
                 obj_name = log.object_mapping.content_type.name.title()
 
-        message_template = self.SYNC_STATUS_MESSAGES.get(
-            log.status, _("%(obj_name)s sync is pending")
-        )
+        message_template = self.SYNC_STATUS_MESSAGES.get(log.status, _("%(obj_name)s sync is pending"))
         text = message_template % {"obj_name": obj_name}
 
         if self.search_query and self.search_query.lower() not in str(text).lower():
@@ -226,9 +214,7 @@ class ActivityLogSequence:
         self._len = len(combined)
 
 
-def get_hubspot_activity_logs(
-    event, filter_type=None, date_from=None, date_to=None, search_query=None
-):
+def get_hubspot_activity_logs(event, filter_type=None, date_from=None, date_to=None, search_query=None):
     from .models import AuditLog, SyncLog
 
     connection_actions = [
@@ -239,9 +225,7 @@ def get_hubspot_activity_logs(
     ]
 
     if filter_type in [None, "settings"]:
-        audit_logs = AuditLog.objects.filter(event=event).exclude(
-            action__in=connection_actions
-        )
+        audit_logs = AuditLog.objects.filter(event=event).exclude(action__in=connection_actions)
         if date_from:
             dt_from = make_aware(datetime.combine(date_from, time.min))
             audit_logs = audit_logs.filter(created_at__gte=dt_from)
@@ -252,9 +236,7 @@ def get_hubspot_activity_logs(
         audit_logs = AuditLog.objects.none()
 
     if filter_type in [None, "sync"]:
-        sync_logs = SyncLog.objects.filter(event=event).select_related(
-            "object_mapping__content_type"
-        )
+        sync_logs = SyncLog.objects.filter(event=event).select_related("object_mapping__content_type")
         if date_from:
             dt_from = make_aware(datetime.combine(date_from, time.min))
             sync_logs = sync_logs.filter(created_at__gte=dt_from)

--- a/hubspot/utils.py
+++ b/hubspot/utils.py
@@ -1,12 +1,12 @@
 import base64
 import hashlib
+from datetime import datetime, time
 from functools import lru_cache
 
 from cryptography.fernet import Fernet
 from django.conf import settings
-from django.utils.translation import gettext_lazy as _
 from django.utils.timezone import make_aware
-from datetime import datetime, time
+from django.utils.translation import gettext_lazy as _
 
 
 @lru_cache(maxsize=1)

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -6,16 +6,17 @@ import urllib.parse
 
 import requests
 from django.contrib import messages
-from django.shortcuts import redirect
-from django.urls import reverse
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
+from django.forms import modelformset_factory
+from django.shortcuts import redirect
+from django.urls import reverse
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, TemplateView, View
 from django_scopes import scope
 from eventyay.base.models import Event, Order, OrderPosition, Organizer
-
 from eventyay.control.permissions import (
     EventPermissionRequiredMixin,
     OrganizerPermissionRequiredMixin,
@@ -25,14 +26,12 @@ from eventyay.control.views.organizer_views.organizer_detail_view_mixin import (
     OrganizerDetailViewMixin,
 )
 
-from django.contrib.contenttypes.models import ContentType
-from django.forms import modelformset_factory
-
+from .field_discovery import get_available_fields
 from .forms import (
-    HubSpotLogFilterForm,
     BaseHubSpotFieldMappingFormSet,
     HubSpotEventSettingsForm,
     HubSpotFieldMappingForm,
+    HubSpotLogFilterForm,
     ObjectTypeMappingFormSet,
 )
 from .models import (
@@ -42,23 +41,22 @@ from .models import (
     HubSpotFieldMapping,
     HubSpotOAuthToken,
     ObjectTypeMapping,
-    OrganizerHubSpotSettings,
     OrganizerHubSpotOAuthToken,
+    OrganizerHubSpotSettings,
     SyncAction,
     SyncDirection,
     SyncLog,
     SyncStatus,
 )
-from .field_discovery import get_available_fields
 from .services import get_hubspot_properties, get_valid_hubspot_token, is_sync_enabled
-from .utils import get_hubspot_activity_logs
-from .tasks import sync_all_mappings_task, sync_order_to_hubspot
 from .sync_logic import (
-    get_sync_status_counts,
-    get_pending_sync_records,
-    get_failed_sync_records,
     clear_sync_status_cache,
+    get_failed_sync_records,
+    get_pending_sync_records,
+    get_sync_status_counts,
 )
+from .tasks import sync_all_mappings_task, sync_order_to_hubspot
+from .utils import get_hubspot_activity_logs
 
 
 def get_client_ip(request):
@@ -834,9 +832,11 @@ class SyncProblemsView(EventPermissionRequiredMixin, PaginationMixin, ListView):
     paginate_by = 25
 
     def get_queryset(self):
-        from .forms import SyncProblemsFilterForm
         from datetime import datetime, time
+
         from django.utils.timezone import make_aware
+
+        from .forms import SyncProblemsFilterForm
 
         self.filter_form = SyncProblemsFilterForm(
             data=self.request.GET, prefix="filter"

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -83,9 +83,7 @@ class EventHubSpotSettingsView(EventPermissionRequiredMixin, TemplateView):
         settings = HubSpotEventSettings.objects.filter(event=self.request.event).first()
         if not settings:
             if data is not None:
-                settings, _ = HubSpotEventSettings.objects.get_or_create(
-                    event=self.request.event
-                )
+                settings, _ = HubSpotEventSettings.objects.get_or_create(event=self.request.event)
             else:
                 settings = HubSpotEventSettings(
                     event=self.request.event,
@@ -156,11 +154,7 @@ class EventHubSpotSettingsView(EventPermissionRequiredMixin, TemplateView):
             if settings_form.is_valid():
                 if "auto_sync_enabled" in settings_form.changed_data:
                     is_enabled = settings_form.cleaned_data["auto_sync_enabled"]
-                    action = (
-                        AuditAction.AUTO_SYNC_ENABLED
-                        if is_enabled
-                        else AuditAction.AUTO_SYNC_DISABLED
-                    )
+                    action = AuditAction.AUTO_SYNC_ENABLED if is_enabled else AuditAction.AUTO_SYNC_DISABLED
                     AuditLog.objects.create(
                         organizer=request.event.organizer,
                         event=request.event,
@@ -173,12 +167,8 @@ class EventHubSpotSettingsView(EventPermissionRequiredMixin, TemplateView):
         else:
             return redirect(request.path)
 
-        messages.error(
-            request, _("We could not save your changes. See below for details.")
-        )
-        return self.render_to_response(
-            self.get_context_data(formset=formset, settings_form=settings_form)
-        )
+        messages.error(request, _("We could not save your changes. See below for details."))
+        return self.render_to_response(self.get_context_data(formset=formset, settings_form=settings_form))
 
 
 class EventHubSpotConnectView(EventPermissionRequiredMixin, View):
@@ -194,22 +184,19 @@ class EventHubSpotConnectView(EventPermissionRequiredMixin, View):
 
         redirect_uri = os.environ.get("HUBSPOT_REDIRECT_URI", "")
         if not redirect_uri:
-            redirect_uri = request.build_absolute_uri(
-                reverse("plugins:hubspot:callback")
-            )
+            redirect_uri = request.build_absolute_uri(reverse("plugins:hubspot:callback"))
 
         params = {
             "client_id": os.environ.get("HUBSPOT_CLIENT_ID", ""),
             "redirect_uri": redirect_uri,
             "scope": os.environ.get(
                 "HUBSPOT_SCOPES",
-                "oauth crm.objects.contacts.read crm.objects.contacts.write crm.objects.deals.read crm.objects.deals.write",
+                "oauth crm.objects.contacts.read crm.objects.contacts.write "
+                "crm.objects.deals.read crm.objects.deals.write",
             ),
             "state": state,
         }
-        url = "https://app.hubspot.com/oauth/authorize?" + urllib.parse.urlencode(
-            params
-        )
+        url = "https://app.hubspot.com/oauth/authorize?" + urllib.parse.urlencode(params)
         return redirect(url)
 
 
@@ -230,11 +217,7 @@ class EventHubSpotCallbackView(View):
 
         is_organizer_flow = len(parts) == 2
 
-        if (
-            not state_token
-            or not organizer_slug
-            or (not is_organizer_flow and not event_slug)
-        ):
+        if not state_token or not organizer_slug or (not is_organizer_flow and not event_slug):
             raise PermissionDenied(_("Invalid state parameter."))
 
         saved_state = request.session.pop("hubspot_oauth_state", None)
@@ -256,9 +239,7 @@ class EventHubSpotCallbackView(View):
         if error:
             messages.error(
                 request,
-                _("HubSpot authorization failed: {}").format(
-                    error_description or error
-                ),
+                _("HubSpot authorization failed: {}").format(error_description or error),
             )
             return redirect(settings_url)
 
@@ -276,12 +257,8 @@ class EventHubSpotCallbackView(View):
             except Organizer.DoesNotExist:
                 raise PermissionDenied(_("Organizer not found."))
 
-            if not request.user.has_organizer_permission(
-                organizer, "can_change_organizer_settings", request=request
-            ):
-                raise PermissionDenied(
-                    _("You do not have permission to view this content.")
-                )
+            if not request.user.has_organizer_permission(organizer, "can_change_organizer_settings", request=request):
+                raise PermissionDenied(_("You do not have permission to view this content."))
         else:
             try:
                 event = Event.objects.select_related("organizer").get(
@@ -294,15 +271,11 @@ class EventHubSpotCallbackView(View):
             if not request.user.has_event_permission(
                 event.organizer, event, "can_change_event_settings", request=request
             ):
-                raise PermissionDenied(
-                    _("You do not have permission to view this content.")
-                )
+                raise PermissionDenied(_("You do not have permission to view this content."))
 
         redirect_uri = os.environ.get("HUBSPOT_REDIRECT_URI", "")
         if not redirect_uri:
-            redirect_uri = request.build_absolute_uri(
-                reverse("plugins:hubspot:callback")
-            )
+            redirect_uri = request.build_absolute_uri(reverse("plugins:hubspot:callback"))
 
         response = requests.post(
             "https://api.hubapi.com/oauth/v1/token",
@@ -322,9 +295,7 @@ class EventHubSpotCallbackView(View):
 
         data = response.json()
         expires_in = data.get("expires_in")
-        expires_at = (
-            now() + datetime.timedelta(seconds=expires_in) if expires_in else None
-        )
+        expires_at = now() + datetime.timedelta(seconds=expires_in) if expires_in else None
 
         # Fetch portal info from HubSpot token info endpoint
         hub_id = ""
@@ -356,14 +327,13 @@ class EventHubSpotCallbackView(View):
                         "hub_name": hub_name,
                         "scope": os.environ.get(
                             "HUBSPOT_SCOPES",
-                            "oauth crm.objects.contacts.read crm.objects.contacts.write crm.objects.deals.read crm.objects.deals.write",
+                            "oauth crm.objects.contacts.read crm.objects.contacts.write "
+                            "crm.objects.deals.read crm.objects.deals.write",
                         ),
                     },
                 )
 
-                OrganizerHubSpotSettings.objects.update_or_create(
-                    organizer=organizer, defaults={"sync_enabled": True}
-                )
+                OrganizerHubSpotSettings.objects.update_or_create(organizer=organizer, defaults={"sync_enabled": True})
 
                 AuditLog.objects.create(
                     organizer=organizer,
@@ -384,14 +354,13 @@ class EventHubSpotCallbackView(View):
                         "hub_name": hub_name,
                         "scope": os.environ.get(
                             "HUBSPOT_SCOPES",
-                            "oauth crm.objects.contacts.read crm.objects.contacts.write crm.objects.deals.read crm.objects.deals.write",
+                            "oauth crm.objects.contacts.read crm.objects.contacts.write "
+                            "crm.objects.deals.read crm.objects.deals.write",
                         ),
                     },
                 )
 
-                HubSpotEventSettings.objects.update_or_create(
-                    event=event, defaults={"sync_enabled": True}
-                )
+                HubSpotEventSettings.objects.update_or_create(event=event, defaults={"sync_enabled": True})
 
                 SyncLog.objects.create(
                     event=event,
@@ -435,9 +404,7 @@ class EventHubSpotDisconnectView(EventPermissionRequiredMixin, View):
                 response = requests.delete(revoke_url, timeout=10)
                 if not response.ok:
                     logger = logging.getLogger(__name__)
-                    logger.warning(
-                        f"Failed to revoke HubSpot token: {response.status_code} {response.text}"
-                    )
+                    logger.warning(f"Failed to revoke HubSpot token: {response.status_code} {response.text}")
             except requests.RequestException as e:
                 logger = logging.getLogger(__name__)
                 logger.warning(f"Error reaching HubSpot revoke endpoint: {e}")
@@ -446,9 +413,7 @@ class EventHubSpotDisconnectView(EventPermissionRequiredMixin, View):
                 token.delete()
         except HubSpotOAuthToken.DoesNotExist:
             with scope(organizer=request.event.organizer):
-                has_org_token = OrganizerHubSpotOAuthToken.objects.filter(
-                    organizer=request.event.organizer
-                ).exists()
+                has_org_token = OrganizerHubSpotOAuthToken.objects.filter(organizer=request.event.organizer).exists()
                 if not has_org_token or not is_sync_enabled(request.event):
                     messages.info(request, _("Not connected to HubSpot."))
                     return redirect(settings_url)
@@ -540,13 +505,9 @@ class EventHubSpotLogView(EventPermissionRequiredMixin, PaginationMixin, ListVie
                         elif item["id"].startswith("sync_"):
                             sync_ids.append(int(item["id"].split("_")[1]))
                     if audit_ids:
-                        AuditLog.objects.filter(
-                            event=request.event, id__in=audit_ids
-                        ).delete()
+                        AuditLog.objects.filter(event=request.event, id__in=audit_ids).delete()
                     if sync_ids:
-                        SyncLog.objects.filter(
-                            event=request.event, id__in=sync_ids
-                        ).delete()
+                        SyncLog.objects.filter(event=request.event, id__in=sync_ids).delete()
                 else:
                     # If no search query, we can directly delete the querysets
                     qs.audit_logs.delete()
@@ -568,18 +529,12 @@ class EventHubSpotLogView(EventPermissionRequiredMixin, PaginationMixin, ListVie
                             pass
 
                 if audit_ids:
-                    AuditLog.objects.filter(
-                        event=request.event, id__in=audit_ids
-                    ).delete()
+                    AuditLog.objects.filter(event=request.event, id__in=audit_ids).delete()
                 if sync_ids:
-                    SyncLog.objects.filter(
-                        event=request.event, id__in=sync_ids
-                    ).delete()
+                    SyncLog.objects.filter(event=request.event, id__in=sync_ids).delete()
 
             messages.success(request, _("Selected logs have been deleted."))
-            return redirect(
-                request.path_info + "?" + request.META.get("QUERY_STRING", "")
-            )
+            return redirect(request.path_info + "?" + request.META.get("QUERY_STRING", ""))
 
         return self.get(request, *args, **kwargs)
 
@@ -619,14 +574,10 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
             can_delete=True,
         )
 
-        eventyay_fields = get_available_fields(
-            mapping.eventyay_object_type, event=request.event
-        )
+        eventyay_fields = get_available_fields(mapping.eventyay_object_type, event=request.event)
         sync_error = None
         try:
-            hubspot_properties = get_hubspot_properties(
-                request.event, mapping.hubspot_object_type
-            )
+            hubspot_properties = get_hubspot_properties(request.event, mapping.hubspot_object_type)
         except Exception as e:
             logger = logging.getLogger(__name__)
             logger.error(
@@ -634,15 +585,10 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
                 request.event.slug,
                 e,
             )
-            sync_error = _(
-                "Could not retrieve HubSpot properties. "
-                "Please check your connection and try again."
-            )
+            sync_error = _("Could not retrieve HubSpot properties. " "Please check your connection and try again.")
             hubspot_properties = []
 
-        error_key = (
-            f"hubspot_properties_error_{request.event.id}_{mapping.hubspot_object_type}"
-        )
+        error_key = f"hubspot_properties_error_{request.event.id}_{mapping.hubspot_object_type}"
         if cache.get(error_key):
             sync_error = _(
                 "HubSpot properties sync failed repeatedly. "
@@ -650,10 +596,7 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
             )
 
         is_fetching_properties = (
-            cache.get(
-                f"hubspot_manual_sync_lock_{request.event.id}_{mapping.hubspot_object_type}"
-            )
-            is not None
+            cache.get(f"hubspot_manual_sync_lock_{request.event.id}_{mapping.hubspot_object_type}") is not None
         )
 
         form_kwargs = {
@@ -677,9 +620,7 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
         if request.GET.get("force_sync") == "1":
             mapping_id = self.kwargs.get("mapping_id")
             try:
-                mapping = ObjectTypeMapping.objects.get(
-                    pk=mapping_id, event=request.event
-                )
+                mapping = ObjectTypeMapping.objects.get(pk=mapping_id, event=request.event)
             except ObjectTypeMapping.DoesNotExist:
                 raise PermissionDenied(_("Invalid object mapping."))
 
@@ -693,9 +634,7 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
 
                 from .tasks import refresh_hubspot_properties_task
 
-                refresh_hubspot_properties_task.apply_async(
-                    args=[request.event.id, mapping.hubspot_object_type]
-                )
+                refresh_hubspot_properties_task.apply_async(args=[request.event.id, mapping.hubspot_object_type])
                 messages.success(request, _("Sync task started in the background."))
             else:
                 messages.error(request, _("Please wait a moment before trying again."))
@@ -726,9 +665,7 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
         context["is_fetching_properties"] = setup.get("is_fetching_properties", False)
 
         if "formset" not in context:
-            context["formset"] = setup["FormSet"](
-                queryset=setup["queryset"], form_kwargs=setup["form_kwargs"]
-            )
+            context["formset"] = setup["FormSet"](queryset=setup["queryset"], form_kwargs=setup["form_kwargs"])
 
         context["has_rows"] = setup["queryset"].exists()
 
@@ -738,9 +675,7 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
         mapping_id = self.kwargs.get("mapping_id")
         setup = self._get_formset_kwargs(mapping_id, request)
 
-        formset = setup["FormSet"](
-            request.POST, queryset=setup["queryset"], form_kwargs=setup["form_kwargs"]
-        )
+        formset = setup["FormSet"](request.POST, queryset=setup["queryset"], form_kwargs=setup["form_kwargs"])
 
         if formset.is_valid():
             instances = formset.save(commit=False)
@@ -765,9 +700,7 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
                 ip_address=get_client_ip(request),
             )
 
-            messages.success(
-                request, _("Field mapping configuration saved successfully.")
-            )
+            messages.success(request, _("Field mapping configuration saved successfully."))
             return redirect(
                 reverse(
                     "plugins:hubspot:mapping_fields",
@@ -781,13 +714,9 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
         else:
             messages.error(
                 request,
-                _(
-                    "There were errors saving your configuration. Please check the form."
-                ),
+                _("There were errors saving your configuration. Please check the form."),
             )
-            return self.render_to_response(
-                self.get_context_data(setup=setup, formset=formset)
-            )
+            return self.render_to_response(self.get_context_data(setup=setup, formset=formset))
 
 
 class EventHubSpotSyncMappingView(EventPermissionRequiredMixin, View):
@@ -816,9 +745,7 @@ class EventHubSpotSyncMappingView(EventPermissionRequiredMixin, View):
 
         messages.success(
             request,
-            _(
-                "Mapping sync started in the background. Depending on the amount of data, this may take a few minutes."
-            ),
+            _("Mapping sync started in the background. Depending on the amount of data, this may take a few minutes."),
         )
         return redirect(settings_url)
 
@@ -838,9 +765,7 @@ class SyncProblemsView(EventPermissionRequiredMixin, PaginationMixin, ListView):
 
         from .forms import SyncProblemsFilterForm
 
-        self.filter_form = SyncProblemsFilterForm(
-            data=self.request.GET, prefix="filter"
-        )
+        self.filter_form = SyncProblemsFilterForm(data=self.request.GET, prefix="filter")
 
         status_filter = ""
         query = ""
@@ -864,25 +789,16 @@ class SyncProblemsView(EventPermissionRequiredMixin, PaginationMixin, ListView):
             records = [
                 r
                 for r in records
-                if query in r["code"].lower()
-                or (r["error_message"] and query in r["error_message"].lower())
+                if query in r["code"].lower() or (r["error_message"] and query in r["error_message"].lower())
             ]
 
         # Filter by dates (only applies to records with last_attempted_at, i.e., failed records)
         if date_from:
             dt_from = make_aware(datetime.combine(date_from, time.min))
-            records = [
-                r
-                for r in records
-                if r["last_attempted_at"] and r["last_attempted_at"] >= dt_from
-            ]
+            records = [r for r in records if r["last_attempted_at"] and r["last_attempted_at"] >= dt_from]
         if date_to:
             dt_to = make_aware(datetime.combine(date_to, time.max))
-            records = [
-                r
-                for r in records
-                if r["last_attempted_at"] and r["last_attempted_at"] <= dt_to
-            ]
+            records = [r for r in records if r["last_attempted_at"] and r["last_attempted_at"] <= dt_to]
 
         # Make error messages more human-readable
         for r in records:
@@ -890,22 +806,11 @@ class SyncProblemsView(EventPermissionRequiredMixin, PaginationMixin, ListView):
                 err = str(r["error_message"])
                 # Map common HubSpot errors
                 if "409 Client Error" in err or "already exists" in err:
-                    r["error_readable"] = _(
-                        "This record already exists in HubSpot and could not be updated."
-                    )
-                elif (
-                    "400 Client Error" in err or "Property values were not valid" in err
-                ):
-                    r["error_readable"] = _(
-                        "One or more mapped fields contain invalid data for HubSpot."
-                    )
-                elif (
-                    "401 Client Error" in err
-                    or "Authentication credentials not found" in err
-                ):
-                    r["error_readable"] = _(
-                        "HubSpot authentication failed. Please reconnect."
-                    )
+                    r["error_readable"] = _("This record already exists in HubSpot and could not be updated.")
+                elif "400 Client Error" in err or "Property values were not valid" in err:
+                    r["error_readable"] = _("One or more mapped fields contain invalid data for HubSpot.")
+                elif "401 Client Error" in err or "Authentication credentials not found" in err:
+                    r["error_readable"] = _("HubSpot authentication failed. Please reconnect.")
                 else:
                     r["error_readable"] = _("An unexpected error occurred during sync.")
             else:
@@ -919,9 +824,7 @@ class SyncProblemsView(EventPermissionRequiredMixin, PaginationMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["filter_form"] = getattr(self, "filter_form", None)
-        context["has_failed"] = any(
-            r["status"] == "failed" for r in get_failed_sync_records(self.request.event)
-        )
+        context["has_failed"] = any(r["status"] == "failed" for r in get_failed_sync_records(self.request.event))
         return context
 
 
@@ -980,22 +883,17 @@ class SyncRetryBulkView(EventPermissionRequiredMixin, View):
         if order_ids:
             # Validate IDs belong to this event
             valid_order_ids = set(
-                Order.objects.filter(event=request.event, id__in=order_ids).values_list(
-                    "id", flat=True
-                )
+                Order.objects.filter(event=request.event, id__in=order_ids).values_list("id", flat=True)
             )
             valid_order_ids_str = {str(i) for i in valid_order_ids}
             validated_order_ids = [o for o in order_ids if o in valid_order_ids_str]
 
             if validated_order_ids:
                 for order_id in validated_order_ids:
-                    sync_order_to_hubspot.apply_async(
-                        args=[int(order_id), request.event.id]
-                    )
+                    sync_order_to_hubspot.apply_async(args=[int(order_id), request.event.id])
                 messages.success(
                     request,
-                    _("Retry queued for %(count)d orders.")
-                    % {"count": len(validated_order_ids)},
+                    _("Retry queued for %(count)d orders.") % {"count": len(validated_order_ids)},
                 )
             else:
                 messages.warning(request, _("No valid records selected."))
@@ -1118,9 +1016,7 @@ class SyncOrderNowView(EventPermissionRequiredMixin, View):
         )
 
 
-class OrganizerHubSpotSettingsView(
-    OrganizerPermissionRequiredMixin, OrganizerDetailViewMixin, TemplateView
-):
+class OrganizerHubSpotSettingsView(OrganizerPermissionRequiredMixin, OrganizerDetailViewMixin, TemplateView):
     """Organizer-level settings page for HubSpot."""
 
     template_name = "hubspot/organizer_settings.html"
@@ -1137,38 +1033,18 @@ class OrganizerHubSpotSettingsView(
         except OrganizerHubSpotOAuthToken.DoesNotExist:
             context["is_connected"] = False
 
-        settings, _created = OrganizerHubSpotSettings.objects.get_or_create(
-            organizer=self.request.organizer
-        )
+        settings, _created = OrganizerHubSpotSettings.objects.get_or_create(organizer=self.request.organizer)
         context["sync_enabled"] = settings.sync_enabled
 
-        events = list(
-            self.request.organizer.events.all().order_by("-date_from", "name")
-        )
+        events = list(self.request.organizer.events.all().order_by("-date_from", "name"))
         if not events:
             context["events"] = []
             return context
 
-        settings_map = dict(
-            HubSpotEventSettings.objects.filter(event__in=events).values_list(
-                "event", "sync_enabled"
-            )
-        )
-        tokens_set = set(
-            HubSpotOAuthToken.objects.filter(event__in=events).values_list(
-                "event", flat=True
-            )
-        )
-        obj_mappings_set = set(
-            ObjectTypeMapping.objects.filter(event__in=events).values_list(
-                "event", flat=True
-            )
-        )
-        field_mappings_set = set(
-            HubSpotFieldMapping.objects.filter(event__in=events).values_list(
-                "event", flat=True
-            )
-        )
+        settings_map = dict(HubSpotEventSettings.objects.filter(event__in=events).values_list("event", "sync_enabled"))
+        tokens_set = set(HubSpotOAuthToken.objects.filter(event__in=events).values_list("event", flat=True))
+        obj_mappings_set = set(ObjectTypeMapping.objects.filter(event__in=events).values_list("event", flat=True))
+        field_mappings_set = set(HubSpotFieldMapping.objects.filter(event__in=events).values_list("event", flat=True))
 
         for event in events:
             # Toggle state
@@ -1187,9 +1063,7 @@ class OrganizerHubSpotSettingsView(
                 event.connection_badge_class = "muted"
 
             # Mapping status
-            has_mappings = (
-                event.id in obj_mappings_set or event.id in field_mappings_set
-            )
+            has_mappings = event.id in obj_mappings_set or event.id in field_mappings_set
             if has_mappings:
                 event.mapping_status_text = _("Custom")
                 event.mapping_badge_class = "primary"
@@ -1203,9 +1077,7 @@ class OrganizerHubSpotSettingsView(
     def post(self, request, *args, **kwargs):
         form_type = request.POST.get("form_type")
         if form_type == "toggle":
-            settings, created = OrganizerHubSpotSettings.objects.get_or_create(
-                organizer=request.organizer
-            )
+            settings, created = OrganizerHubSpotSettings.objects.get_or_create(organizer=request.organizer)
             settings.sync_enabled = request.POST.get("sync_enabled") == "on"
             settings.save()
 
@@ -1220,10 +1092,7 @@ class OrganizerHubSpotSettingsView(
         elif form_type == "events_toggle":
             event_ids = request.POST.getlist("event_ids")
             events = list(request.organizer.events.filter(id__in=event_ids))
-            existing_settings = {
-                s.event_id: s
-                for s in HubSpotEventSettings.objects.filter(event__in=events)
-            }
+            existing_settings = {s.event_id: s for s in HubSpotEventSettings.objects.filter(event__in=events)}
             to_create = []
             to_update = []
             for event in events:
@@ -1234,9 +1103,7 @@ class OrganizerHubSpotSettingsView(
                         ev_settings.sync_enabled = is_checked
                         to_update.append(ev_settings)
                 else:
-                    to_create.append(
-                        HubSpotEventSettings(event=event, sync_enabled=is_checked)
-                    )
+                    to_create.append(HubSpotEventSettings(event=event, sync_enabled=is_checked))
 
             if to_create:
                 HubSpotEventSettings.objects.bulk_create(to_create)
@@ -1274,22 +1141,19 @@ class OrganizerHubSpotConnectView(OrganizerPermissionRequiredMixin, View):
 
         redirect_uri = os.environ.get("HUBSPOT_REDIRECT_URI", "")
         if not redirect_uri:
-            redirect_uri = request.build_absolute_uri(
-                reverse("plugins:hubspot:callback")
-            )
+            redirect_uri = request.build_absolute_uri(reverse("plugins:hubspot:callback"))
 
         params = {
             "client_id": os.environ.get("HUBSPOT_CLIENT_ID", ""),
             "redirect_uri": redirect_uri,
             "scope": os.environ.get(
                 "HUBSPOT_SCOPES",
-                "oauth crm.objects.contacts.read crm.objects.contacts.write crm.objects.deals.read crm.objects.deals.write",
+                "oauth crm.objects.contacts.read crm.objects.contacts.write "
+                "crm.objects.deals.read crm.objects.deals.write",
             ),
             "state": state,
         }
-        url = "https://app.hubspot.com/oauth/authorize?" + urllib.parse.urlencode(
-            params
-        )
+        url = "https://app.hubspot.com/oauth/authorize?" + urllib.parse.urlencode(params)
         return redirect(url)
 
 
@@ -1312,31 +1176,25 @@ class OrganizerHubSpotDisconnectView(OrganizerPermissionRequiredMixin, View):
 
         # Attempt to revoke at HubSpot
         try:
-            revoke_url = (
-                f"https://api.hubapi.com/oauth/v1/refresh-tokens/{token.refresh_token}"
-            )
+            revoke_url = f"https://api.hubapi.com/oauth/v1/refresh-tokens/{token.refresh_token}"
             response = requests.delete(revoke_url, timeout=10)
             if not response.ok:
                 logger = logging.getLogger(__name__)
-                logger.warning(
-                    f"Failed to revoke HubSpot organizer token: {response.status_code} {response.text}"
-                )
+                logger.warning(f"Failed to revoke HubSpot organizer token: {response.status_code} {response.text}")
         except requests.RequestException as e:
             logger = logging.getLogger(__name__)
             logger.warning(f"Error reaching HubSpot revoke endpoint: {e}")
 
         with scope(organizer=request.organizer):
             token.delete()
-            OrganizerHubSpotSettings.objects.filter(organizer=request.organizer).update(
-                sync_enabled=False
-            )
+            OrganizerHubSpotSettings.objects.filter(organizer=request.organizer).update(sync_enabled=False)
 
-            events_with_tokens = HubSpotOAuthToken.objects.filter(
-                event__organizer=request.organizer
-            ).values_list("event_id", flat=True)
-            HubSpotEventSettings.objects.filter(
-                event__organizer=request.organizer
-            ).exclude(event_id__in=events_with_tokens).update(sync_enabled=False)
+            events_with_tokens = HubSpotOAuthToken.objects.filter(event__organizer=request.organizer).values_list(
+                "event_id", flat=True
+            )
+            HubSpotEventSettings.objects.filter(event__organizer=request.organizer).exclude(
+                event_id__in=events_with_tokens
+            ).update(sync_enabled=False)
 
             AuditLog.objects.create(
                 organizer=request.organizer,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,11 @@ omit = [
 
 [tool.ruff]
 line-length = 120
+extend-exclude = ["*/migrations/*"]
 
 [tool.ruff.format]
 indent-style = "space"
-quote-style = "single"
+quote-style = "double"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "PLE", "PLW", "UP"]
@@ -73,7 +74,6 @@ ignore = ["E722", "E741"]
 
 [tool.ruff.lint.per-file-ignores]
 "**/__init__.py" = ["F401"]
-"**/migrations/*.py" = ["E501"]
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,15 @@ source = ["hubspot"]
 omit = [
     "*/migrations/*",
 ]
+
+[tool.ruff]
+line-length = 88
+exclude = [
+    "*/migrations/*",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+ignore = ["E501", "B904"]
+
+[tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,19 @@ omit = [
 ]
 
 [tool.ruff]
-line-length = 88
-exclude = [
-    "*/migrations/*",
-]
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "B", "UP"]
-ignore = ["E501", "B904"]
+line-length = 120
 
 [tool.ruff.format]
+indent-style = "space"
+quote-style = "single"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "PLE", "PLW", "UP"]
+ignore = ["E722", "E741"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/__init__.py" = ["F401"]
+"**/migrations/*.py" = ["E501"]
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
-import pytest
-from eventyay.base.models import Event, Organizer, Team, User, Order
-from django.utils.timezone import now
 from datetime import timedelta
+
+import pytest
+from django.utils.timezone import now
+from eventyay.base.models import Event, Order, Organizer, Team, User
 
 
 @pytest.fixture

--- a/tests/test_audit_log_ui.py
+++ b/tests/test_audit_log_ui.py
@@ -3,14 +3,15 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django_scopes import scope
 from eventyay.base.models import Event
+
 from hubspot.models import (
-    AuditLog,
-    SyncLog,
     AuditAction,
+    AuditLog,
+    HubSpotObjectMapping,
     SyncAction,
     SyncDirection,
+    SyncLog,
     SyncStatus,
-    HubSpotObjectMapping,
 )
 
 
@@ -54,7 +55,6 @@ def test_hubspot_logs_view_all_entries(
     settings.SITE_URL = "https://testserver"
 
     with scope(organizer=event.organizer):
-
         AuditLog.objects.create(
             organizer=event.organizer,
             event=event,
@@ -175,8 +175,9 @@ def test_hubspot_logs_view_permission_denied(
 def test_hubspot_logs_view_order_and_position_synced_formatting(
     logged_in_organizer_client, organizer, event, settings
 ):
-    from django.utils.timezone import now
     from datetime import timedelta
+
+    from django.utils.timezone import now
     from eventyay.base.models import Order, OrderPosition, Product
 
     settings.SITE_URL = "https://testserver"

--- a/tests/test_audit_log_ui.py
+++ b/tests/test_audit_log_ui.py
@@ -16,9 +16,7 @@ from hubspot.models import (
 
 
 @pytest.mark.django_db
-def test_hubspot_settings_recent_activity_preview(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_settings_recent_activity_preview(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
 
     with scope(organizer=event.organizer):
@@ -26,9 +24,7 @@ def test_hubspot_settings_recent_activity_preview(
             AuditLog.objects.create(
                 organizer=event.organizer,
                 event=event,
-                action=(
-                    AuditAction.CONNECT if i % 2 == 0 else AuditAction.MAPPING_UPDATED
-                ),
+                action=(AuditAction.CONNECT if i % 2 == 0 else AuditAction.MAPPING_UPDATED),
                 ip_address="127.0.0.1",
             )
 
@@ -49,9 +45,7 @@ def test_hubspot_settings_recent_activity_preview(
 
 
 @pytest.mark.django_db
-def test_hubspot_logs_view_all_entries(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_logs_view_all_entries(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
 
     with scope(organizer=event.organizer):
@@ -95,9 +89,7 @@ def test_hubspot_logs_view_all_entries(
 
 
 @pytest.mark.django_db
-def test_hubspot_logs_view_specific_synced_object(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_logs_view_specific_synced_object(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
 
     with scope(organizer=event.organizer):
@@ -130,14 +122,10 @@ def test_hubspot_logs_view_specific_synced_object(
 
 
 @pytest.mark.django_db
-def test_hubspot_logs_view_other_event_entries_not_shown(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_logs_view_other_event_entries_not_shown(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
 
-    event2 = Event.objects.create(
-        organizer=organizer, name="Event 2", slug="event2", date_from=event.date_from
-    )
+    event2 = Event.objects.create(organizer=organizer, name="Event 2", slug="event2", date_from=event.date_from)
 
     with scope(organizer=event.organizer):
         AuditLog.objects.create(
@@ -158,9 +146,7 @@ def test_hubspot_logs_view_other_event_entries_not_shown(
 
 
 @pytest.mark.django_db
-def test_hubspot_logs_view_permission_denied(
-    logged_in_client, organizer, event, settings
-):
+def test_hubspot_logs_view_permission_denied(logged_in_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse(
         "plugins:hubspot:logs",
@@ -172,9 +158,7 @@ def test_hubspot_logs_view_permission_denied(
 
 
 @pytest.mark.django_db
-def test_hubspot_logs_view_order_and_position_synced_formatting(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_logs_view_order_and_position_synced_formatting(logged_in_organizer_client, organizer, event, settings):
     from datetime import timedelta
 
     from django.utils.timezone import now
@@ -252,14 +236,14 @@ def test_hubspot_logs_view_order_and_position_synced_formatting(
     assert "Order ABCDE (buyer@example.com) synced to HubSpot successfully" in content
 
     # The position synced log text should contain position representation, order code and attendee name
-    expected_pos_message = "Order Position #1 – Standard Ticket for Order ABCDE (John Doe) synced to HubSpot successfully"
+    expected_pos_message = (
+        "Order Position #1 – Standard Ticket for Order ABCDE (John Doe) synced to HubSpot successfully"
+    )
     assert expected_pos_message in content
 
 
 @pytest.mark.django_db
-def test_hubspot_logs_view_auto_sync_actions(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_logs_view_auto_sync_actions(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
 
     with scope(organizer=event.organizer):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,10 +10,10 @@ from hubspot.client import (
     HubSpotPermanentError,
     HubSpotTransientError,
     create_record,
-    update_record,
     get_record,
+    update_record,
 )
-from hubspot.models import HubSpotOAuthToken, HubSpotEventSettings
+from hubspot.models import HubSpotEventSettings, HubSpotOAuthToken
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,9 +84,7 @@ def test_create_409_raises_conflict(mock_post, event, hubspot_token):
     mock_post_response = mock.Mock()
     mock_post_response.ok = False
     mock_post_response.status_code = 409
-    mock_post_response.json.return_value = {
-        "message": "Contact already exists. Existing ID: 98765"
-    }
+    mock_post_response.json.return_value = {"message": "Contact already exists. Existing ID: 98765"}
     mock_post.return_value = mock_post_response
 
     from hubspot.client import HubSpotConflictError

--- a/tests/test_field_discovery.py
+++ b/tests/test_field_discovery.py
@@ -54,9 +54,7 @@ def test_get_available_fields_order():
 
 @pytest.mark.django_db
 def test_get_available_fields_order_position_no_event():
-    with pytest.raises(
-        ValueError, match="event is required when object_type is 'order_position'"
-    ):
+    with pytest.raises(ValueError, match="event is required when object_type is 'order_position'"):
         get_available_fields("order_position")
 
 

--- a/tests/test_field_discovery.py
+++ b/tests/test_field_discovery.py
@@ -1,7 +1,7 @@
 import pytest
+from django_scopes import scope
 from eventyay.base.models import Question
 
-from django_scopes import scope
 from hubspot.field_discovery import get_available_fields
 
 

--- a/tests/test_field_mapping.py
+++ b/tests/test_field_mapping.py
@@ -1,11 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-
+from django_scopes import scope, scopes_disabled
 from eventyay.base.models import Order
-from hubspot.models import HubSpotFieldMapping, SyncMode, ObjectTypeMapping
-from django_scopes import scopes_disabled, scope
-from unittest.mock import patch
+
+from hubspot.models import HubSpotFieldMapping, ObjectTypeMapping, SyncMode
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_field_mapping.py
+++ b/tests/test_field_mapping.py
@@ -98,9 +98,7 @@ def test_valid_save_one_identifier(
 
 
 @pytest.mark.django_db
-def test_no_identifier_blocks_save(
-    logged_in_organizer_client, mapping_url, organizer, event, settings
-):
+def test_no_identifier_blocks_save(logged_in_organizer_client, mapping_url, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     data = {
         "form-TOTAL_FORMS": "1",
@@ -120,9 +118,7 @@ def test_no_identifier_blocks_save(
 
 
 @pytest.mark.django_db
-def test_multiple_identifiers_blocks_save(
-    logged_in_organizer_client, mapping_url, organizer, event, settings
-):
+def test_multiple_identifiers_blocks_save(logged_in_organizer_client, mapping_url, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     data = {
         "form-TOTAL_FORMS": "2",
@@ -146,9 +142,7 @@ def test_multiple_identifiers_blocks_save(
 
 
 @pytest.mark.django_db
-def test_incompatible_types_warning_but_saves(
-    logged_in_organizer_client, mapping_url, organizer, event, settings
-):
+def test_incompatible_types_warning_but_saves(logged_in_organizer_client, mapping_url, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     # Mapping a boolean (testmode) to a string (dealname)
     data = {
@@ -171,9 +165,7 @@ def test_incompatible_types_warning_but_saves(
 
 
 @pytest.mark.django_db
-def test_compatible_types_save_without_warning(
-    logged_in_organizer_client, mapping_url, organizer, event, settings
-):
+def test_compatible_types_save_without_warning(logged_in_organizer_client, mapping_url, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     data = {
         "form-TOTAL_FORMS": "1",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 import pytest
-from django.db import IntegrityError, transaction
-
 from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError, transaction
 
 from hubspot.models import (
     HubSpotEventSettings,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -13,9 +13,7 @@ from hubspot.models import (
 
 
 @pytest.mark.django_db
-def test_connect_view_redirects_to_hubspot(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_connect_view_redirects_to_hubspot(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse(
         "plugins:hubspot:connect",
@@ -53,9 +51,7 @@ def test_callback_view_success(logged_in_organizer_client, organizer, event, set
 
     url = reverse("plugins:hubspot:callback")
     state_param = f"valid_state:{organizer.slug}:{event.slug}"
-    response = logged_in_organizer_client.get(
-        url, {"state": state_param, "code": "auth_code"}
-    )
+    response = logged_in_organizer_client.get(url, {"state": state_param, "code": "auth_code"})
 
     assert response.status_code == 302
     assert response.url == reverse(
@@ -72,9 +68,7 @@ def test_callback_view_success(logged_in_organizer_client, organizer, event, set
 
 
 @pytest.mark.django_db
-def test_callback_view_invalid_state(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_callback_view_invalid_state(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
 
     session = logged_in_organizer_client.session
@@ -83,9 +77,7 @@ def test_callback_view_invalid_state(
 
     url = reverse("plugins:hubspot:callback")
     state_param = f"invalid_state:{organizer.slug}:{event.slug}"
-    response = logged_in_organizer_client.get(
-        url, {"state": state_param, "code": "auth_code"}
-    )
+    response = logged_in_organizer_client.get(url, {"state": state_param, "code": "auth_code"})
 
     assert response.status_code == 302
     messages = list(get_messages(response.wsgi_request))
@@ -95,9 +87,7 @@ def test_callback_view_invalid_state(
 
 
 @pytest.mark.django_db
-def test_callback_view_hubspot_error(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_callback_view_hubspot_error(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
 
     url = reverse("plugins:hubspot:callback")
@@ -118,9 +108,7 @@ def test_callback_view_hubspot_error(
 
 @pytest.mark.django_db
 @responses.activate
-def test_callback_view_api_error(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_callback_view_api_error(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
 
     responses.add(
@@ -136,9 +124,7 @@ def test_callback_view_api_error(
 
     url = reverse("plugins:hubspot:callback")
     state_param = f"valid_state:{organizer.slug}:{event.slug}"
-    response = logged_in_organizer_client.get(
-        url, {"state": state_param, "code": "auth_code"}
-    )
+    response = logged_in_organizer_client.get(url, {"state": state_param, "code": "auth_code"})
 
     assert response.status_code == 302
     messages = list(get_messages(response.wsgi_request))
@@ -148,9 +134,7 @@ def test_callback_view_api_error(
 
 
 @pytest.mark.django_db
-def test_org_connect_view_redirects_to_hubspot(
-    logged_in_organizer_client, organizer, settings
-):
+def test_org_connect_view_redirects_to_hubspot(logged_in_organizer_client, organizer, settings):
     team = organizer.teams.first()
     team.can_change_organizer_settings = True
     team.save()
@@ -171,9 +155,7 @@ def test_org_connect_view_redirects_to_hubspot(
 
 @pytest.mark.django_db
 @responses.activate
-def test_callback_view_success_organizer(
-    logged_in_organizer_client, organizer, settings
-):
+def test_callback_view_success_organizer(logged_in_organizer_client, organizer, settings):
     team = organizer.teams.first()
     team.can_change_organizer_settings = True
     team.save()
@@ -198,9 +180,7 @@ def test_callback_view_success_organizer(
 
     url = reverse("plugins:hubspot:callback")
     state_param = f"valid_state:{organizer.slug}"
-    response = logged_in_organizer_client.get(
-        url, {"state": state_param, "code": "auth_code"}
-    )
+    response = logged_in_organizer_client.get(url, {"state": state_param, "code": "auth_code"})
 
     assert response.status_code == 302
     assert response.url == reverse(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2,14 +2,13 @@ import pytest
 import responses
 from django.contrib.messages import get_messages
 from django.urls import reverse
-
 from django_scopes import scope
 
 from hubspot.models import (
     HubSpotOAuthToken,
-    SyncLog,
-    SyncAction,
     OrganizerHubSpotOAuthToken,
+    SyncAction,
+    SyncLog,
 )
 
 

--- a/tests/test_object_mappings.py
+++ b/tests/test_object_mappings.py
@@ -22,15 +22,11 @@ def _connect_event(event):
 
 
 @pytest.mark.django_db
-def test_mappings_listed_on_settings(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_mappings_listed_on_settings(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     _connect_event(event)
     with scope(organizer=organizer):
-        ObjectTypeMapping.objects.create(
-            event=event, eventyay_object_type="order", hubspot_object_type="contacts"
-        )
+        ObjectTypeMapping.objects.create(event=event, eventyay_object_type="order", hubspot_object_type="contacts")
     url = _settings_url(organizer, event)
     response = logged_in_organizer_client.get(url)
     assert response.status_code == 200
@@ -64,9 +60,7 @@ def test_create_object_mapping(logged_in_organizer_client, organizer, event, set
 
 
 @pytest.mark.django_db
-def test_duplicate_mapping_blocked(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_duplicate_mapping_blocked(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     _connect_event(event)
     url = _settings_url(organizer, event)

--- a/tests/test_object_mappings.py
+++ b/tests/test_object_mappings.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 from django_scopes import scope
 
-from hubspot.models import ObjectTypeMapping, HubSpotOAuthToken, HubSpotEventSettings
+from hubspot.models import HubSpotEventSettings, HubSpotOAuthToken, ObjectTypeMapping
 
 
 def _settings_url(organizer, event):

--- a/tests/test_order_detail.py
+++ b/tests/test_order_detail.py
@@ -175,9 +175,7 @@ def test_order_info_pending_no_mapping(client, event, order, organizer):
 
 @pytest.mark.django_db
 @mock.patch("hubspot.views.sync_order_to_hubspot.apply_async")
-def test_sync_now_view(
-    mock_apply, logged_in_organizer_client, event, order, organizer, settings
-):
+def test_sync_now_view(mock_apply, logged_in_organizer_client, event, order, organizer, settings):
     settings.SITE_URL = "https://testserver"
 
     order.status = Order.STATUS_PAID

--- a/tests/test_order_detail.py
+++ b/tests/test_order_detail.py
@@ -1,20 +1,21 @@
 import datetime
-from django.utils.timezone import now
-import pytest
 from unittest import mock
+
+import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from django.utils.timezone import now
 from django_scopes import scopes_disabled
-
 from eventyay.base.models import Order
+
 from hubspot.models import (
     HubSpotEventSettings,
     HubSpotOAuthToken,
     HubSpotObjectMapping,
-    SyncLog,
-    SyncStatus,
     SyncAction,
     SyncDirection,
+    SyncLog,
+    SyncStatus,
 )
 from hubspot.signals import control_order_info
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,24 +1,24 @@
 import datetime
-import requests
 from unittest import mock
 
 import pytest
+import requests
+from django.core.cache import cache
 from django.utils.timezone import now
 from django_scopes import scope
-from django.core.cache import cache
 
 from hubspot.models import (
-    HubSpotOAuthToken,
     HubSpotEventSettings,
-    OrganizerHubSpotSettings,
+    HubSpotOAuthToken,
     OrganizerHubSpotOAuthToken,
+    OrganizerHubSpotSettings,
 )
 from hubspot.services import (
-    get_valid_hubspot_token,
-    get_hubspot_properties,
-    sync_hubspot_properties,
     HubSpotFetchError,
+    get_hubspot_properties,
+    get_valid_hubspot_token,
     is_sync_enabled,
+    sync_hubspot_properties,
 )
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -72,9 +72,7 @@ def test_token_expiring_soon_is_refreshed(mock_post, event, hubspot_token):
 @pytest.mark.django_db
 @mock.patch("hubspot.services.requests.post")
 def test_concurrent_refresh_attempts(mock_post, event, hubspot_token):
-    with mock.patch(
-        "hubspot.models.HubSpotOAuthToken.objects.select_for_update"
-    ) as mock_sfu:
+    with mock.patch("hubspot.models.HubSpotOAuthToken.objects.select_for_update") as mock_sfu:
         mock_qs = mock.Mock()
         mock_sfu.return_value = mock_qs
         mock_qs.get.return_value = hubspot_token
@@ -88,9 +86,7 @@ def test_concurrent_refresh_attempts(mock_post, event, hubspot_token):
 @pytest.mark.django_db
 @mock.patch("hubspot.tasks.refresh_hubspot_properties_task.apply_async")
 @mock.patch("hubspot.services.requests.get")
-def test_sync_hubspot_properties_success_and_cache(
-    mock_get, mock_task, event, hubspot_token
-):
+def test_sync_hubspot_properties_success_and_cache(mock_get, mock_task, event, hubspot_token):
     cache.clear()
 
     mock_response_1 = mock.Mock()
@@ -150,9 +146,7 @@ def test_get_hubspot_properties_ttl_expiry(mock_task, event, hubspot_token):
     data_key = f"hubspot_properties_{event.id}_contact"
     cached_data = {
         "fetched_at": now() - datetime.timedelta(minutes=15),
-        "properties": [
-            {"key": "firstname", "label": "First Name", "data_type": "text"}
-        ],
+        "properties": [{"key": "firstname", "label": "First Name", "data_type": "text"}],
     }
     cache.set(data_key, cached_data)
 
@@ -168,9 +162,7 @@ def test_get_hubspot_properties_ttl_expiry(mock_task, event, hubspot_token):
 def test_sync_hubspot_properties_no_token(event, caplog):
     cache.clear()
     with scope(organizer=event.organizer):
-        with pytest.raises(
-            HubSpotFetchError, match="Not connected to HubSpot or token is invalid"
-        ):
+        with pytest.raises(HubSpotFetchError, match="Not connected to HubSpot or token is invalid"):
             sync_hubspot_properties(event, "contact")
 
 
@@ -188,14 +180,13 @@ def test_sync_hubspot_properties_api_failure(mock_get, event, hubspot_token, cap
 @pytest.mark.django_db
 @mock.patch("hubspot.tasks.refresh_hubspot_properties_task.apply_async")
 @mock.patch("hubspot.services.requests.get")
-def test_get_hubspot_properties_error_suppression(
-    mock_get, mock_task, event, hubspot_token
-):
+def test_get_hubspot_properties_error_suppression(mock_get, mock_task, event, hubspot_token):
     cache.clear()
     error_key = f"hubspot_properties_error_{event.id}_contact"
     cache.set(error_key, "Max retries exceeded")
 
-    # When error_key is set and force_sync is False, get_hubspot_properties should not fetch synchronously or trigger task
+    # When error_key is set and force_sync is False, get_hubspot_properties should not
+    # fetch synchronously or trigger task
     with scope(organizer=event.organizer):
         props = get_hubspot_properties(event, "contact", force_sync=False)
 
@@ -209,9 +200,7 @@ def test_get_hubspot_properties_error_suppression(
         data_key,
         {
             "fetched_at": now() - datetime.timedelta(minutes=15),
-            "properties": [
-                {"key": "firstname", "label": "First Name", "data_type": "text"}
-            ],
+            "properties": [{"key": "firstname", "label": "First Name", "data_type": "text"}],
         },
     )
     with scope(organizer=event.organizer):
@@ -231,9 +220,7 @@ def test_get_hubspot_properties_auto_sync_rate_limit(mock_task, event, hubspot_t
         data_key,
         {
             "fetched_at": now() - datetime.timedelta(minutes=15),
-            "properties": [
-                {"key": "firstname", "label": "First Name", "data_type": "text"}
-            ],
+            "properties": [{"key": "firstname", "label": "First Name", "data_type": "text"}],
         },
     )
     with scope(organizer=event.organizer):
@@ -276,18 +263,14 @@ def test_is_sync_enabled_event_level_with_token(event, hubspot_token):
 @pytest.mark.django_db
 def test_is_sync_enabled_organizer_level_no_token(event):
     with scope(organizer=event.organizer):
-        OrganizerHubSpotSettings.objects.create(
-            organizer=event.organizer, sync_enabled=True
-        )
+        OrganizerHubSpotSettings.objects.create(organizer=event.organizer, sync_enabled=True)
         assert is_sync_enabled(event) is False
 
 
 @pytest.mark.django_db
 def test_is_sync_enabled_organizer_level_with_token(event):
     with scope(organizer=event.organizer):
-        OrganizerHubSpotSettings.objects.create(
-            organizer=event.organizer, sync_enabled=True
-        )
+        OrganizerHubSpotSettings.objects.create(organizer=event.organizer, sync_enabled=True)
         OrganizerHubSpotOAuthToken.objects.create(
             organizer=event.organizer,
             access_token="org_access",
@@ -301,9 +284,7 @@ def test_is_sync_enabled_organizer_level_with_token(event):
 def test_is_sync_enabled_event_level_disabled_fallback_to_organizer(event):
     with scope(organizer=event.organizer):
         HubSpotEventSettings.objects.create(event=event, sync_enabled=False)
-        OrganizerHubSpotSettings.objects.create(
-            organizer=event.organizer, sync_enabled=True
-        )
+        OrganizerHubSpotSettings.objects.create(organizer=event.organizer, sync_enabled=True)
         OrganizerHubSpotOAuthToken.objects.create(
             organizer=event.organizer,
             access_token="org_access",

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -34,9 +34,7 @@ def test_enqueue_sync_skipped_if_disabled(mock_apply, event, order):
 
 @pytest.mark.django_db
 @mock.patch("hubspot.signals.sync_order_to_hubspot.apply_async")
-def test_enqueue_sync_success(
-    mock_apply, event, order, django_capture_on_commit_callbacks
-):
+def test_enqueue_sync_success(mock_apply, event, order, django_capture_on_commit_callbacks):
     HubSpotEventSettings.objects.create(event=event, sync_enabled=True)
     from hubspot.models import HubSpotOAuthToken
 
@@ -54,14 +52,10 @@ def test_enqueue_sync_success(
 
 @pytest.mark.django_db
 @mock.patch("hubspot.signals.sync_order_to_hubspot.apply_async")
-def test_enqueue_sync_auto_sync_disabled(
-    mock_apply, event, order, django_capture_on_commit_callbacks
-):
+def test_enqueue_sync_auto_sync_disabled(mock_apply, event, order, django_capture_on_commit_callbacks):
     from hubspot.models import SyncLog, SyncStatus
 
-    HubSpotEventSettings.objects.create(
-        event=event, sync_enabled=True, auto_sync_enabled=False
-    )
+    HubSpotEventSettings.objects.create(event=event, sync_enabled=True, auto_sync_enabled=False)
     from hubspot.models import HubSpotOAuthToken
 
     HubSpotOAuthToken.objects.create(

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,10 +1,12 @@
 import datetime
-from django.utils.timezone import now
-import pytest
 from unittest import mock
+
+import pytest
+from django.utils.timezone import now
+from django_scopes import scopes_disabled
+
 from hubspot.models import HubSpotEventSettings
 from hubspot.signals import _enqueue_hubspot_sync
-from django_scopes import scopes_disabled
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_sync_problems.py
+++ b/tests/test_sync_problems.py
@@ -1,21 +1,22 @@
 import pytest
-from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
 from django.utils.timezone import now
-from eventyay.base.models import Order
 from django_scopes import scope
+from eventyay.base.models import Order
+
 from hubspot.models import (
-    HubSpotOAuthToken,
+    EventyayObjectType,
     HubSpotEventSettings,
-    ObjectTypeMapping,
-    HubSpotObjectMapping,
     HubSpotFieldMapping,
-    SyncLog,
+    HubSpotOAuthToken,
+    HubSpotObjectMapping,
+    HubSpotObjectType,
+    ObjectTypeMapping,
     SyncAction,
     SyncDirection,
+    SyncLog,
     SyncStatus,
-    EventyayObjectType,
-    HubSpotObjectType,
 )
 
 

--- a/tests/test_sync_problems.py
+++ b/tests/test_sync_problems.py
@@ -46,9 +46,7 @@ def setup_hubspot(event):
 
 
 @pytest.mark.django_db
-def test_sync_status_banner_pending_count(
-    logged_in_organizer_client, event, order, setup_hubspot, settings
-):
+def test_sync_status_banner_pending_count(logged_in_organizer_client, event, order, setup_hubspot, settings):
     with scope(organizer=event.organizer):
         order.status = Order.STATUS_PAID
         order.save()
@@ -64,9 +62,7 @@ def test_sync_status_banner_pending_count(
 
 
 @pytest.mark.django_db
-def test_sync_status_banner_failed_count(
-    logged_in_organizer_client, event, order, setup_hubspot, settings
-):
+def test_sync_status_banner_failed_count(logged_in_organizer_client, event, order, setup_hubspot, settings):
     with scope(organizer=event.organizer):
         order.status = Order.STATUS_PAID
         order.save()
@@ -102,9 +98,7 @@ def test_sync_status_banner_failed_count(
 
 
 @pytest.mark.django_db
-def test_sync_problems_list_view(
-    logged_in_organizer_client, event, order, setup_hubspot, settings
-):
+def test_sync_problems_list_view(logged_in_organizer_client, event, order, setup_hubspot, settings):
     with scope(organizer=event.organizer):
         order.status = Order.STATUS_PAID
         order.save()
@@ -122,9 +116,7 @@ def test_sync_problems_list_view(
 
 
 @pytest.mark.django_db
-def test_dismiss_sync_record(
-    logged_in_organizer_client, event, order, setup_hubspot, settings
-):
+def test_dismiss_sync_record(logged_in_organizer_client, event, order, setup_hubspot, settings):
     with scope(organizer=event.organizer):
         order.status = Order.STATUS_PAID
         order.save()
@@ -160,9 +152,7 @@ def test_dismiss_sync_record(
     assert response.status_code == 302
 
     with scope(organizer=event.organizer):
-        dismiss_log = SyncLog.objects.filter(
-            event=event, object_mapping=om, action=SyncAction.DISMISS
-        ).first()
+        dismiss_log = SyncLog.objects.filter(event=event, object_mapping=om, action=SyncAction.DISMISS).first()
         assert dismiss_log is not None
         assert dismiss_log.status == SyncStatus.SUCCESS
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -82,9 +82,7 @@ def test_sync_skipped_when_disabled(mock_create, mock_event, object_mapping, ord
 @pytest.mark.django_db
 @mock.patch("hubspot.tasks.get_hubspot_properties")
 @mock.patch("hubspot.tasks.create_record")
-def test_sync_order_success(
-    mock_create, mock_get_props, mock_event, object_mapping, order
-):
+def test_sync_order_success(mock_create, mock_get_props, mock_event, object_mapping, order):
     mock_create.return_value = "hub_123"
     mock_get_props.return_value = [{"key": "email", "data_type": "text"}]
 
@@ -117,9 +115,7 @@ def test_sync_order_success(
 @mock.patch("hubspot.tasks.get_hubspot_properties")
 @mock.patch("hubspot.tasks.get_record")
 @mock.patch("hubspot.tasks.update_record")
-def test_sync_modes(
-    mock_update, mock_get_record, mock_get_props, mock_event, object_mapping, order
-):
+def test_sync_modes(mock_update, mock_get_record, mock_get_props, mock_event, object_mapping, order):
     mock_update.return_value = "hub_123"
     mock_get_record.return_value = {"company": "OldCompany", "phone": ""}
 
@@ -179,18 +175,14 @@ def test_sync_modes(
 
     assert "email" in properties_sent
     assert "amount" in properties_sent
-    assert (
-        "locale" not in properties_sent
-    )  # Skipped because Fill if New and record exists
+    assert "locale" not in properties_sent  # Skipped because Fill if New and record exists
 
 
 @pytest.mark.django_db
 @mock.patch("hubspot.tasks.get_hubspot_properties")
 @mock.patch("hubspot.tasks.get_record")
 @mock.patch("hubspot.tasks.update_record")
-def test_sync_fill_if_empty(
-    mock_update, mock_get_record, mock_get_props, mock_event, object_mapping, order
-):
+def test_sync_fill_if_empty(mock_update, mock_get_record, mock_get_props, mock_event, object_mapping, order):
     mock_update.return_value = "hub_123"
     mock_get_record.return_value = {"phone": "", "company": "ExistingCorp"}
 
@@ -231,9 +223,7 @@ def test_sync_fill_if_empty(
 
     InvoiceAddress.objects.create(order=order, company="NewCorp")
 
-    HubSpotFieldMapping.objects.filter(hubspot_property="company").update(
-        eventyay_field="event_name"
-    )
+    HubSpotFieldMapping.objects.filter(hubspot_property="company").update(eventyay_field="event_name")
     order.event.name = "NewEvent"
     order.event.save()
 
@@ -249,9 +239,7 @@ def test_sync_fill_if_empty(
 @mock.patch("hubspot.tasks.get_hubspot_properties")
 @mock.patch("hubspot.tasks.create_record")
 @mock.patch("hubspot.tasks.sync_order_to_hubspot.retry")
-def test_transient_error_retries(
-    mock_retry, mock_create, mock_get_props, mock_event, object_mapping, order
-):
+def test_transient_error_retries(mock_retry, mock_create, mock_get_props, mock_event, object_mapping, order):
     mock_retry.side_effect = Retry()
     mock_create.side_effect = HubSpotTransientError("Timeout", retry_after_seconds=10)
     mock_get_props.return_value = [{"key": "email", "data_type": "text"}]
@@ -280,9 +268,7 @@ def test_transient_error_retries(
 @pytest.mark.django_db
 @mock.patch("hubspot.tasks.get_hubspot_properties")
 @mock.patch("hubspot.tasks.create_record")
-def test_permanent_error_no_retry(
-    mock_create, mock_get_props, mock_event, object_mapping, order
-):
+def test_permanent_error_no_retry(mock_create, mock_get_props, mock_event, object_mapping, order):
     mock_create.side_effect = HubSpotPermanentError("Invalid data", status_code=400)
     mock_get_props.return_value = [{"key": "email", "data_type": "text"}]
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,12 @@
-import pytest
 from unittest import mock
+
+import pytest
+from celery.exceptions import Retry
 from django.contrib.contenttypes.models import ContentType
+from django_scopes import scopes_disabled
 from eventyay.base.models import InvoiceAddress
+
+from hubspot.client import HubSpotPermanentError, HubSpotTransientError
 from hubspot.models import (
     HubSpotEventSettings,
     HubSpotFieldMapping,
@@ -15,9 +20,6 @@ from hubspot.tasks import (
     _convert_value,
     sync_order_to_hubspot,
 )
-from hubspot.client import HubSpotTransientError, HubSpotPermanentError
-from django_scopes import scopes_disabled
-from celery.exceptions import Retry
 
 
 @pytest.fixture(autouse=True)
@@ -43,9 +45,11 @@ def test_convert_value():
 @pytest.fixture
 def mock_event(event):
     HubSpotEventSettings.objects.create(event=event, sync_enabled=True)
-    from hubspot.models import HubSpotOAuthToken
-    from django.utils.timezone import now
     import datetime
+
+    from django.utils.timezone import now
+
+    from hubspot.models import HubSpotOAuthToken
 
     HubSpotOAuthToken.objects.create(
         event=event,
@@ -305,9 +309,10 @@ def test_permanent_error_no_retry(
 @pytest.mark.django_db
 @mock.patch("hubspot.tasks.sync_hubspot_properties")
 def test_refresh_hubspot_properties_task_retries_and_error(mock_sync, mock_event):
-    from hubspot.tasks import refresh_hubspot_properties_task
-    from hubspot.services import HubSpotFetchError
     from django.core.cache import cache
+
+    from hubspot.services import HubSpotFetchError
+    from hubspot.tasks import refresh_hubspot_properties_task
 
     cache.clear()
     assert refresh_hubspot_properties_task.max_retries == 3

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,7 +1,8 @@
 import pytest
 from django.urls import reverse
 from django_scopes import scope
-from hubspot.models import HubSpotOAuthToken, HubSpotEventSettings
+
+from hubspot.models import HubSpotEventSettings, HubSpotOAuthToken
 
 
 @pytest.mark.django_db

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -6,9 +6,7 @@ from hubspot.models import HubSpotEventSettings, HubSpotOAuthToken
 
 
 @pytest.mark.django_db
-def test_disconnected_shows_connect_button(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_disconnected_shows_connect_button(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse(
         "plugins:hubspot:hubspot",
@@ -23,9 +21,7 @@ def test_disconnected_shows_connect_button(
 
 
 @pytest.mark.django_db
-def test_connected_shows_disconnect_button_and_portal_info(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_connected_shows_disconnect_button_and_portal_info(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     with scope(organizer=organizer):
         HubSpotOAuthToken.objects.create(
@@ -52,9 +48,7 @@ def test_connected_shows_disconnect_button_and_portal_info(
 
 
 @pytest.mark.django_db
-def test_no_token_values_in_rendered_output(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_no_token_values_in_rendered_output(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     with scope(organizer=organizer):
         token = HubSpotOAuthToken.objects.create(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -30,9 +30,7 @@ def test_hubspot_settings_view_logged_out(client, organizer, event, settings):
 
 
 @pytest.mark.django_db
-def test_hubspot_settings_view_wrong_organizer(
-    logged_in_client, organizer, event, settings
-):
+def test_hubspot_settings_view_wrong_organizer(logged_in_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse(
         "plugins:hubspot:hubspot",
@@ -43,9 +41,7 @@ def test_hubspot_settings_view_wrong_organizer(
 
 
 @pytest.mark.django_db
-def test_hubspot_settings_view_correct_organizer(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_settings_view_correct_organizer(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse(
         "plugins:hubspot:hubspot",
@@ -56,9 +52,7 @@ def test_hubspot_settings_view_correct_organizer(
 
 
 @pytest.mark.django_db
-def test_hubspot_disconnect_view_not_connected(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_disconnect_view_not_connected(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse(
         "plugins:hubspot:disconnect",
@@ -74,14 +68,10 @@ def test_hubspot_disconnect_view_not_connected(
 
 @pytest.mark.django_db
 @mock.patch("hubspot.views.requests.delete")
-def test_hubspot_disconnect_view_connected(
-    mock_delete, logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_disconnect_view_connected(mock_delete, logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     with scope(organizer=event.organizer):
-        HubSpotOAuthToken.objects.create(
-            event=event, access_token="old_access", refresh_token="old_refresh"
-        )
+        HubSpotOAuthToken.objects.create(event=event, access_token="old_access", refresh_token="old_refresh")
 
     mock_response = mock.Mock()
     mock_response.ok = True
@@ -120,9 +110,7 @@ def test_hubspot_disconnect_view_revoke_failure_still_clears(
 ):
     settings.SITE_URL = "https://testserver"
     with scope(organizer=event.organizer):
-        HubSpotOAuthToken.objects.create(
-            event=event, access_token="old_access", refresh_token="old_refresh"
-        )
+        HubSpotOAuthToken.objects.create(event=event, access_token="old_access", refresh_token="old_refresh")
 
     # Simulate a network error or 500 from HubSpot
 
@@ -142,18 +130,14 @@ def test_hubspot_disconnect_view_revoke_failure_still_clears(
 
 
 @pytest.mark.django_db
-def test_hubspot_settings_save_auto_sync_audit_log(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_hubspot_settings_save_auto_sync_audit_log(logged_in_organizer_client, organizer, event, settings):
     from hubspot.models import AuditAction, AuditLog, HubSpotEventSettings
 
     settings.SITE_URL = "https://testserver"
 
     # Get settings or create
     with scope(organizer=event.organizer):
-        HubSpotEventSettings.objects.get_or_create(
-            event=event, defaults={"auto_sync_enabled": True}
-        )
+        HubSpotEventSettings.objects.get_or_create(event=event, defaults={"auto_sync_enabled": True})
 
     url = reverse(
         "plugins:hubspot:hubspot",
@@ -172,9 +156,7 @@ def test_hubspot_settings_save_auto_sync_audit_log(
     assert response.status_code == 302
 
     with scope(organizer=event.organizer):
-        assert AuditLog.objects.filter(
-            event=event, action=AuditAction.AUTO_SYNC_DISABLED
-        ).exists()
+        assert AuditLog.objects.filter(event=event, action=AuditAction.AUTO_SYNC_DISABLED).exists()
 
     # Enable auto_sync again
     response = logged_in_organizer_client.post(
@@ -187,9 +169,7 @@ def test_hubspot_settings_save_auto_sync_audit_log(
     assert response.status_code == 302
 
     with scope(organizer=event.organizer):
-        assert AuditLog.objects.filter(
-            event=event, action=AuditAction.AUTO_SYNC_ENABLED
-        ).exists()
+        assert AuditLog.objects.filter(event=event, action=AuditAction.AUTO_SYNC_ENABLED).exists()
 
 
 @pytest.mark.django_db
@@ -234,9 +214,7 @@ def test_organizer_settings_view_lists_only_organizer_events(
 
 
 @pytest.mark.django_db
-def test_organizer_settings_view_connection_and_mapping_status(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_organizer_settings_view_connection_and_mapping_status(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     with scope(organizer=organizer):
         # Setup event with custom token and custom mapping
@@ -290,9 +268,7 @@ def test_organizer_settings_view_connection_and_mapping_status(
 
     # Now disable sync for event2 specifically
     with scope(organizer=organizer):
-        HubSpotEventSettings.objects.update_or_create(
-            event=event2, defaults={"sync_enabled": False}
-        )
+        HubSpotEventSettings.objects.update_or_create(event=event2, defaults={"sync_enabled": False})
 
     response = logged_in_organizer_client.get(url)
     assert response.status_code == 200
@@ -303,9 +279,7 @@ def test_organizer_settings_view_connection_and_mapping_status(
 
 
 @pytest.mark.django_db
-def test_organizer_settings_view_single_save_action(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_organizer_settings_view_single_save_action(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     with scope(organizer=organizer):
         event2 = Event.objects.create(
@@ -339,9 +313,7 @@ def test_organizer_settings_view_single_save_action(
 
 
 @pytest.mark.django_db
-def test_event_hubspot_settings_view_organizer_fallback(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_event_hubspot_settings_view_organizer_fallback(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     with scope(organizer=organizer):
         OrganizerHubSpotOAuthToken.objects.create(
@@ -366,9 +338,7 @@ def test_event_hubspot_settings_view_organizer_fallback(
 
     # Now disable sync specifically for this event
     with scope(organizer=organizer):
-        HubSpotEventSettings.objects.update_or_create(
-            event=event, defaults={"sync_enabled": False}
-        )
+        HubSpotEventSettings.objects.update_or_create(event=event, defaults={"sync_enabled": False})
 
     response = logged_in_organizer_client.get(url)
     assert response.status_code == 200
@@ -376,9 +346,7 @@ def test_event_hubspot_settings_view_organizer_fallback(
 
 
 @pytest.mark.django_db
-def test_organizer_settings_view_your_events_panel_visibility(
-    logged_in_organizer_client, organizer, settings
-):
+def test_organizer_settings_view_your_events_panel_visibility(logged_in_organizer_client, organizer, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse("plugins:hubspot:org_hubspot", kwargs={"organizer": organizer.slug})
 
@@ -389,9 +357,7 @@ def test_organizer_settings_view_your_events_panel_visibility(
 
     # When main toggle is enabled, Your Events panel should be visible in HTML
     with scope(organizer=organizer):
-        OrganizerHubSpotSettings.objects.update_or_create(
-            organizer=organizer, defaults={"sync_enabled": True}
-        )
+        OrganizerHubSpotSettings.objects.update_or_create(organizer=organizer, defaults={"sync_enabled": True})
 
     response = logged_in_organizer_client.get(url)
     assert response.status_code == 200

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,18 +1,20 @@
-import pytest
-from django.urls import reverse
-from unittest import mock
-from django_scopes import scope
-from django.utils.timezone import now
 from datetime import timedelta
+from unittest import mock
+
+import pytest
+import requests
+from django.urls import reverse
+from django.utils.timezone import now
+from django_scopes import scope
 from eventyay.base.models import Event, Organizer
+
 from hubspot.models import (
     HubSpotEventSettings,
     HubSpotOAuthToken,
     ObjectTypeMapping,
-    OrganizerHubSpotSettings,
     OrganizerHubSpotOAuthToken,
+    OrganizerHubSpotSettings,
 )
-import requests
 
 
 @pytest.mark.django_db
@@ -143,7 +145,7 @@ def test_hubspot_disconnect_view_revoke_failure_still_clears(
 def test_hubspot_settings_save_auto_sync_audit_log(
     logged_in_organizer_client, organizer, event, settings
 ):
-    from hubspot.models import AuditLog, AuditAction, HubSpotEventSettings
+    from hubspot.models import AuditAction, AuditLog, HubSpotEventSettings
 
     settings.SITE_URL = "https://testserver"
 


### PR DESCRIPTION
# Closes #24 

Based on the audit of the `eventyay-hubspot` repository, `flake8` and `isort` are not currently in use. Formatting was handled by `black` via `pre-commit`. The following checklist details the steps required to complete the migration to standardizing on `ruff` for all linting and formatting.

## 1. Add Ruff Configuration
- [x] Update `pyproject.toml` to include a `[tool.ruff]` section.
- [x] Add `[tool.ruff.lint]` configuration (e.g., `select = ["E", "F", "I", "B", "UP"]`).
- [x] Add `[tool.ruff.format]` configuration (to replace `black`).
- [x] Set `line-length = 88` (or the repository's preferred standard) to maintain consistency with `black`.

## 2. Update dependencies
- [x] Remove mentions of `black` from the contributor setup instructions in `README.md`.

## 3. Update Pre-commit Configuration
- [x] In `.pre-commit-config.yaml`, remove the `black` repository and hook.
- [x] In `.pre-commit-config.yaml`, ensure the `ruff-pre-commit` repository contains both the `ruff` (for linting) and `ruff-format` (for formatting) hooks.

## 4. Apply Formatting and Lint Fixes
- [x] Run `ruff check . --fix` locally to apply safe linting fixes (and sort imports).
- [x] Run `ruff format .` locally to format all files.
- [x] Review any generated changes carefully to ensure no unrelated code changes are introduced.

## 5. Update Documentation
- [x] Update `README.md` code style section. Replace `pip install pre-commit ruff black` with `pip install pre-commit ruff`.

## Summary by Sourcery

Standardize code formatting and linting across the HubSpot plugin by adopting Ruff and applying repository-wide style updates.

Enhancements:
- Reformat HubSpot app modules and tests to consistent import ordering, line wrapping, and minor style cleanups without altering behavior.

Build:
- Add Ruff configuration to pyproject.toml, including linting and formatting settings aligned with the project line length and rules.

CI:
- Update pre-commit hooks to remove Black and use Ruff for linting plus ruff-format for code formatting.

Documentation:
- Update README contributor instructions to reference Ruff-only formatting instead of Black.