### PR TITLE
refactor: move hubspot under ticket settings

### DIFF
--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -20,7 +20,7 @@ from eventyay.base.signals import (
     periodic_task,
     register_global_settings,
 )
-from eventyay.control.signals import nav_event, nav_organizer, order_info
+from eventyay.control.signals import nav_event_settings, nav_organizer, order_info
 
 from .models import (
     AuditLog,
@@ -75,12 +75,12 @@ def register_global_settings_receiver(sender, **kwargs):
     )
 
 
-@receiver(nav_event, dispatch_uid="hubspot_nav")
+@receiver(nav_event_settings, dispatch_uid="hubspot_nav")
 def control_nav_import(sender, request=None, **kwargs):
     url = resolve(request.path_info)
     return [
         {
-            "label": _("Hubspot"),
+            "label": _("HubSpot Integration"),
             "url": reverse(
                 "plugins:hubspot:hubspot",
                 kwargs={
@@ -89,7 +89,6 @@ def control_nav_import(sender, request=None, **kwargs):
                 },
             ),
             "active": url.namespace == "plugins:hubspot" and url.url_name == "hubspot",
-            "icon": "bar-chart",
         }
     ]
 


### PR DESCRIPTION
## Closes [#5083](https://github.com/fossasia/eventyay/issues/5083)

<img width="1420" height="749" alt="Screenshot 2026-08-21 at 4 06 38 PM" src="https://github.com/user-attachments/assets/f44ae35f-5a05-43cd-8fa8-8c489f9d33b3" />

---

<img width="1427" height="754" alt="Screenshot 2026-08-21 at 4 08 00 PM" src="https://github.com/user-attachments/assets/b2c0b597-8968-4180-904e-b14c94244cc5" />

## Summary by Sourcery

Enhancements:
- Move the HubSpot integration navigation entry into the event ticket settings menu and update its label to “HubSpot Integration.”