### PR TITLE
fix: Change hubspot integraton to hubspot

### DIFF
--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -80,7 +80,7 @@ def control_nav_import(sender, request=None, **kwargs):
     url = resolve(request.path_info)
     return [
         {
-            "label": _("HubSpot Integration"),
+            "label": _("HubSpot"),
             "url": reverse(
                 "plugins:hubspot:hubspot",
                 kwargs={


### PR DESCRIPTION
## Closes [#5083](https://github.com/fossasia/eventyay/issues/5083)

<img width="1414" height="749" alt="Screenshot 2026-08-21 at 5 07 39 PM" src="https://github.com/user-attachments/assets/033c978e-a74e-4f16-83a0-8748c9a9bd34" />

---

<img width="1417" height="749" alt="Screenshot 2026-08-21 at 5 07 30 PM" src="https://github.com/user-attachments/assets/efd524e8-8e10-4dcf-b5eb-c7e33737cb88" />

## Summary by Sourcery

Bug Fixes:
- Rename the HubSpot navigation label to consistently display “HubSpot” instead of “HubSpot Integration”.