### PR TITLE
refactor: removes all env checks and support except .env.hubspot for local dev

### DIFF
--- a/hubspot/apps.py
+++ b/hubspot/apps.py
@@ -36,7 +36,10 @@ class EventyayHubspotPluginApp(PluginConfig):
         plugin_dir = Path(__file__).resolve().parent.parent
         env_path = plugin_dir / ".env.hubspot"
         if env_path.exists():
-            from dotenv import load_dotenv
-
-            load_dotenv(dotenv_path=env_path)
-            logger.info(f"HubSpot plugin loaded dev environment variables from: {env_path}")
+            try:
+                from dotenv import load_dotenv
+            except ImportError:
+                logger.warning("python-dotenv is not installed; skipping .env.hubspot loading")
+            else:
+                load_dotenv(dotenv_path=env_path)
+                logger.info(f"HubSpot plugin loaded dev environment variables from: {env_path}")

--- a/hubspot/apps.py
+++ b/hubspot/apps.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
-from dotenv import load_dotenv
 
 from . import __version__
 
@@ -28,28 +27,16 @@ class EventyayHubspotPluginApp(PluginConfig):
 
     def ready(self):
         from . import signals  # NOQA
-        from django.conf import settings
         import logging
 
         logger = logging.getLogger(__name__)
 
+        # .env.hubspot is only for local development convenience.
+        # In production, configure credentials via the admin UI (Global Settings).
         plugin_dir = Path(__file__).resolve().parent.parent
-        project_root = getattr(settings, "PROJECT_ROOT", plugin_dir)
-        env_paths = [
-            plugin_dir / ".env.hubspot",
-            project_root / ".env",
-            Path.cwd() / ".env",
-            project_root.parent / ".env.dev",
-            project_root.parent / ".env",
-            plugin_dir / ".env",
-        ]
+        env_path = plugin_dir / ".env.hubspot"
+        if env_path.exists():
+            from dotenv import load_dotenv
 
-        env_loaded = False
-        for env_path in env_paths:
-            if env_path.exists():
-                load_dotenv(dotenv_path=env_path)
-                logger.info(f"HubSpot plugin loaded environment variables from: {env_path}")
-                env_loaded = True
-
-        if not env_loaded:
-            logger.error("HubSpot plugin: No .env file found.")
+            load_dotenv(dotenv_path=env_path)
+            logger.info(f"HubSpot plugin loaded dev environment variables from: {env_path}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,11 @@ maintainers = [
 dependencies = [
     "cryptography>=50.0.0",
     "requests",
-    "python-dotenv"
+]
+
+[project.optional-dependencies]
+dev = [
+    "python-dotenv",
 ]
 
 [project.entry-points."pretix.plugin"]


### PR DESCRIPTION
This PR removes the generic, multi-path .env file discovery logic to encourage managing credentials via the Admin UI (Global Settings) in production, while retaining .env.hubspot strictly for local development workflows.

## Summary by Sourcery

Limit environment-file support to optional local development while relying on admin-managed credentials in production.

Enhancements:
- Restrict HubSpot environment loading to the plugin’s local-development `.env.hubspot` file and direct production configuration to the admin UI.
- Make `python-dotenv` an optional development dependency rather than a runtime requirement.